### PR TITLE
fix: adding missing file for linux.

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -37,6 +37,7 @@ project "GLFW"
 			"src/x11_monitor.c",
 			"src/x11_window.c",
 			"src/xkb_unicode.c",
+			"src/posix_module.c",
 			"src/posix_time.c",
 			"src/posix_thread.c",
 			"src/glx_context.c",


### PR DESCRIPTION
The `premake5.lua` is missing the file `src/posix_module.c` preventing any linking on this version of glfw on linux. I'm adding it in this PR.