### PR TITLE
Fixed macOS and Linux builds to work with Hazel patches - for Hazel-linux port

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -39,6 +39,7 @@ project "GLFW"
 			"src/xkb_unicode.c",
 			"src/posix_time.c",
 			"src/posix_thread.c",
+			"src/posix_module.c",
 			"src/glx_context.c",
 			"src/egl_context.c",
 			"src/osmesa_context.c",
@@ -48,6 +49,28 @@ project "GLFW"
 		defines
 		{
 			"_GLFW_X11"
+		}
+
+	filter "system:macosx"
+		pic "On"
+
+		files
+		{
+			"src/cocoa_init.m",
+			"src/cocoa_monitor.m",
+			"src/cocoa_window.m",
+			"src/cocoa_joystick.m",
+			"src/cocoa_time.c",
+			"src/nsgl_context.m",
+			"src/posix_thread.c",
+			"src/posix_module.c",
+			"src/osmesa_context.c",
+			"src/egl_context.c"
+		}
+
+		defines
+		{
+			"_GLFW_COCOA"
 		}
 
 	filter "system:windows"

--- a/src/cocoa_init.m
+++ b/src/cocoa_init.m
@@ -543,13 +543,17 @@ GLFWbool _glfwConnectCocoa(int platformID, _GLFWplatform* platform)
         _glfwGetWindowOpacityCocoa,
         _glfwSetWindowResizableCocoa,
         _glfwSetWindowDecoratedCocoa,
-        _glfwSetWindowFloatingCocoa,
+        _glfwSetWindowFloatingNull,
         _glfwSetWindowOpacityCocoa,
         _glfwSetWindowMousePassthroughCocoa,
         _glfwPollEventsCocoa,
         _glfwWaitEventsCocoa,
         _glfwWaitEventsTimeoutCocoa,
         _glfwPostEmptyEventCocoa,
+
+        // Hazel
+        _glfwSetWindowTitlebarNull,
+
         _glfwGetEGLPlatformCocoa,
         _glfwGetEGLNativeDisplayCocoa,
         _glfwGetEGLNativeWindowCocoa,

--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -1204,6 +1204,10 @@ GLFWbool _glfwConnectX11(int platformID, _GLFWplatform* platform)
         _glfwWaitEventsX11,
         _glfwWaitEventsTimeoutX11,
         _glfwPostEmptyEventX11,
+
+        // Hazel
+        _glfwSetWindowTitlebarNull,
+
         _glfwGetEGLPlatformX11,
         _glfwGetEGLNativeDisplayX11,
         _glfwGetEGLNativeWindowX11,


### PR DESCRIPTION
Currently the Linux port requires the builder to hold local changes against the GLFW fork in order to build correctly.

OSX support is still WIP for the moment (awaiting resolution on a Google SwiftShader bug), but maintaining build support in lieu of runtime support makes future porting efforts easier.