### PR TITLE
Fix missing function pointer to setWindowTitleBar for X11 platform

### DIFF
--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -1204,6 +1204,7 @@ GLFWbool _glfwConnectX11(int platformID, _GLFWplatform* platform)
         _glfwWaitEventsX11,
         _glfwWaitEventsTimeoutX11,
         _glfwPostEmptyEventX11,
+        _glfwPlatformSetWindowTitlebar,
         _glfwGetEGLPlatformX11,
         _glfwGetEGLNativeDisplayX11,
         _glfwGetEGLNativeWindowX11,


### PR DESCRIPTION
The extra field `setWindowTitleBar` was wrongly initialized for the X11 platform in x11_init.c. This led to crashes during window initialization, and also in test applications such as glfwinfo.

(It is possible that it is still missing for other platforms as well)

p.s: I came across this issue while trying to add linux support to Walnut :)