### PR TITLE
Fix imgui window resizing and dragging issue while undocking.

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -38,6 +38,7 @@ project "GLFW"
 			"src/x11_monitor.c",
 			"src/x11_window.c",
 			"src/xkb_unicode.c",
+			"src/posix_module.c",
 			"src/posix_time.c",
 			"src/posix_thread.c",
 			"src/glx_context.c",
@@ -71,11 +72,6 @@ project "GLFW"
 		defines 
 		{ 
 			"_GLFW_WIN32",
-		}
-
-		links
-		{
-			"Dwmapi.lib"
 		}
 
 	filter "configurations:Debug"

--- a/premake5.lua
+++ b/premake5.lua
@@ -70,7 +70,6 @@ project "GLFW"
 		defines 
 		{ 
 			"_GLFW_WIN32",
-			"_CRT_SECURE_NO_WARNINGS"
 		}
 
 		links

--- a/premake5.lua
+++ b/premake5.lua
@@ -2,6 +2,7 @@ project "GLFW"
 	kind "StaticLib"
 	language "C"
 	staticruntime "off"
+	warnings "off"
 
 	targetdir ("bin/" .. outputdir .. "/%{prj.name}")
 	objdir ("bin-int/" .. outputdir .. "/%{prj.name}")

--- a/premake5.lua
+++ b/premake5.lua
@@ -84,9 +84,9 @@ project "GLFW"
 
 	filter "configurations:Release"
 		runtime "Release"
-		optimize "on"
+		optimize "speed"
 
-	filter "configurations:Dist"
+    filter "configurations:Dist"
 		runtime "Release"
-		optimize "on"
+		optimize "speed"
         symbols "off"

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -1011,19 +1011,16 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
 			if (_glfw.hints.window.titlebar || !hasThickFrame || !wParam)
 				break;
 
-			UINT dpi = GetDpiForWindow(hWnd);
-
-			int frame_x = GetSystemMetricsForDpi(SM_CXFRAME, dpi);
-			int frame_y = GetSystemMetricsForDpi(SM_CYFRAME, dpi);
-			int padding = GetSystemMetricsForDpi(92, dpi);
+			const int frame_x = 2.0f * GetSystemMetrics(SM_CXFRAME);
+			const int frame_y = 2.0f * GetSystemMetrics(SM_CYFRAME);
 
 			NCCALCSIZE_PARAMS* params = (NCCALCSIZE_PARAMS*)lParam;
 			RECT* requested_client_rect = params->rgrc;
 
-			requested_client_rect->right -= frame_x + padding;
-			requested_client_rect->left += frame_x + padding;
-			requested_client_rect->bottom -= frame_y + padding;
-			requested_client_rect->top += frame_y + (window->win32.maximized ? 1.0f : -1.0f) * padding;
+			requested_client_rect->right -= frame_x;
+			requested_client_rect->left += frame_x;
+			requested_client_rect->bottom -= frame_y;
+			requested_client_rect->top += window->win32.maximized ? frame_y : 0.0f;
 
 			return 0;
 		}
@@ -1307,15 +1304,13 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg,
 					RECT rc;
 					GetClientRect(hWnd, &rc);
 
-					UINT dpi = GetDpiForWindow(hWnd);
-					int frame_y = GetSystemMetricsForDpi(SM_CYFRAME, dpi);
-					int padding = GetSystemMetricsForDpi(92, dpi);
+					int frame_y = 2.0f * GetSystemMetrics(SM_CYFRAME);
 
 					enum { left = 1, top = 2, right = 4, bottom = 8 };
 					int hit = 0;
 					if (pt.x < border_thickness.left)								hit |= left;
 					if (pt.x > rc.right - border_thickness.right)					hit |= right;
-					if (pt.y < border_thickness.top || pt.y < frame_y + padding)	hit |= top;
+					if (pt.y < border_thickness.top || pt.y < frame_y)				hit |= top;
 					if (pt.y > rc.bottom - border_thickness.bottom)					hit |= bottom;
 
 					if (hit & top && hit & left)        return HTTOPLEFT;


### PR DESCRIPTION
Fixes the two major issue with current implementation of WindowCreation with glfwWindowHint(GLFW_TITLEBAR, GLFW_FALSE);

Issue 1: Not able to Undock the imgui window and drag out of the main window until mouse button is released and window is dragged again. (Removing Line 566 fixes this issue)
Issue 2: Not able to resize imgui windows that are undocked and are out of the main window.

Issues describing video:

https://user-images.githubusercontent.com/29519295/204027256-9521ef11-954d-4d97-aa4c-cfba55872faf.mp4

Fix:

https://user-images.githubusercontent.com/29519295/204028320-650a41f5-a7d4-4c20-a44f-ef171c4b1406.mp4



