### PR TITLE
Fix premake5.lua

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -106,7 +106,8 @@ project "GLFW"
 		runtime "Debug"
 		symbols "on"
 		sanitize { "Address" }
-		flags { "NoRuntimeChecks", "NoIncrementalLink" }
+		runtimechecks "Off"
+        incrementallink "Off"
 
 	filter "configurations:Release"
 		runtime "Release"


### PR DESCRIPTION
In the latest version of premake he field flags has been deprecated and will be removed. Switch to using runtime checks "Off" incrementallink "Off"