### PR TITLE
Improve Wayland support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,5 @@ tests/windows
 # Hazel-specific
 bin
 bin-int
+src/*-client-protocol.h
+src/*-client-protocol-code.h

--- a/deps/wayland/cursor-shape-v1.xml
+++ b/deps/wayland/cursor-shape-v1.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="cursor_shape_v1">
+  <copyright>
+    Copyright 2018 The Chromium Authors
+    Copyright 2023 Simon Ser
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="wp_cursor_shape_manager_v1" version="2">
+    <description summary="cursor shape manager">
+      This global offers an alternative, optional way to set cursor images. This
+      new way uses enumerated cursors instead of a wl_surface like
+      wl_pointer.set_cursor does.
+
+      Warning! The protocol described in this file is currently in the testing
+      phase. Backward compatible changes may be added together with the
+      corresponding interface version bump. Backward incompatible changes can
+      only be done by creating a new major version of the extension.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        Destroy the cursor shape manager.
+      </description>
+    </request>
+
+    <request name="get_pointer">
+      <description summary="manage the cursor shape of a pointer device">
+        Obtain a wp_cursor_shape_device_v1 for a wl_pointer object.
+
+        When the pointer capability is removed from the wl_seat, the
+        wp_cursor_shape_device_v1 object becomes inert.
+      </description>
+      <arg name="cursor_shape_device" type="new_id" interface="wp_cursor_shape_device_v1"/>
+      <arg name="pointer" type="object" interface="wl_pointer"/>
+    </request>
+
+    <request name="get_tablet_tool_v2">
+      <description summary="manage the cursor shape of a tablet tool device">
+        Obtain a wp_cursor_shape_device_v1 for a zwp_tablet_tool_v2 object.
+
+        When the zwp_tablet_tool_v2 is removed, the wp_cursor_shape_device_v1
+        object becomes inert.
+      </description>
+      <arg name="cursor_shape_device" type="new_id" interface="wp_cursor_shape_device_v1"/>
+      <arg name="tablet_tool" type="object" interface="zwp_tablet_tool_v2"/>
+    </request>
+  </interface>
+
+  <interface name="wp_cursor_shape_device_v1" version="2">
+    <description summary="cursor shape for a device">
+      This interface allows clients to set the cursor shape.
+    </description>
+
+    <enum name="shape">
+      <description summary="cursor shapes">
+        This enum describes cursor shapes.
+
+        The names are taken from the CSS W3C specification:
+        https://w3c.github.io/csswg-drafts/css-ui/#cursor
+        with a few additions.
+
+        Note that there are some groups of cursor shapes that are related:
+        The first group is drag-and-drop cursors which are used to indicate
+        the selected action during dnd operations. The second group is resize
+        cursors which are used to indicate resizing and moving possibilities
+        on window borders. It is recommended that the shapes in these groups
+        should use visually compatible images and metaphors.
+      </description>
+      <entry name="default" value="1" summary="default cursor"/>
+      <entry name="context_menu" value="2" summary="a context menu is available for the object under the cursor"/>
+      <entry name="help" value="3" summary="help is available for the object under the cursor"/>
+      <entry name="pointer" value="4" summary="pointer that indicates a link or another interactive element"/>
+      <entry name="progress" value="5" summary="progress indicator"/>
+      <entry name="wait" value="6" summary="program is busy, user should wait"/>
+      <entry name="cell" value="7" summary="a cell or set of cells may be selected"/>
+      <entry name="crosshair" value="8" summary="simple crosshair"/>
+      <entry name="text" value="9" summary="text may be selected"/>
+      <entry name="vertical_text" value="10" summary="vertical text may be selected"/>
+      <entry name="alias" value="11" summary="drag-and-drop: alias of/shortcut to something is to be created"/>
+      <entry name="copy" value="12" summary="drag-and-drop: something is to be copied"/>
+      <entry name="move" value="13" summary="drag-and-drop: something is to be moved"/>
+      <entry name="no_drop" value="14" summary="drag-and-drop: the dragged item cannot be dropped at the current cursor location"/>
+      <entry name="not_allowed" value="15" summary="drag-and-drop: the requested action will not be carried out"/>
+      <entry name="grab" value="16" summary="drag-and-drop: something can be grabbed"/>
+      <entry name="grabbing" value="17" summary="drag-and-drop: something is being grabbed"/>
+      <entry name="e_resize" value="18" summary="resizing: the east border is to be moved"/>
+      <entry name="n_resize" value="19" summary="resizing: the north border is to be moved"/>
+      <entry name="ne_resize" value="20" summary="resizing: the north-east corner is to be moved"/>
+      <entry name="nw_resize" value="21" summary="resizing: the north-west corner is to be moved"/>
+      <entry name="s_resize" value="22" summary="resizing: the south border is to be moved"/>
+      <entry name="se_resize" value="23" summary="resizing: the south-east corner is to be moved"/>
+      <entry name="sw_resize" value="24" summary="resizing: the south-west corner is to be moved"/>
+      <entry name="w_resize" value="25" summary="resizing: the west border is to be moved"/>
+      <entry name="ew_resize" value="26" summary="resizing: the east and west borders are to be moved"/>
+      <entry name="ns_resize" value="27" summary="resizing: the north and south borders are to be moved"/>
+      <entry name="nesw_resize" value="28" summary="resizing: the north-east and south-west corners are to be moved"/>
+      <entry name="nwse_resize" value="29" summary="resizing: the north-west and south-east corners are to be moved"/>
+      <entry name="col_resize" value="30" summary="resizing: that the item/column can be resized horizontally"/>
+      <entry name="row_resize" value="31" summary="resizing: that the item/row can be resized vertically"/>
+      <entry name="all_scroll" value="32" summary="something can be scrolled in any direction"/>
+      <entry name="zoom_in" value="33" summary="something can be zoomed in"/>
+      <entry name="zoom_out" value="34" summary="something can be zoomed out"/>
+      <entry name="dnd_ask" value="35" summary="drag-and-drop: the user will select which action will be carried out (non-css value)" since="2"/>
+      <entry name="all_resize" value="36" summary="resizing: something can be moved or resized in any direction (non-css value)" since="2"/>
+    </enum>
+
+    <enum name="error">
+      <entry name="invalid_shape" value="1"
+        summary="the specified shape value is invalid"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the cursor shape device">
+        Destroy the cursor shape device.
+
+        The device cursor shape remains unchanged.
+      </description>
+    </request>
+
+    <request name="set_shape">
+      <description summary="set device cursor to the shape">
+        Sets the device cursor to the specified shape. The compositor will
+        change the cursor image based on the specified shape.
+
+        The cursor actually changes only if the input device focus is one of
+        the requesting client's surfaces. If any, the previous cursor image
+        (surface or shape) is replaced.
+
+        The "shape" argument must be a valid enum entry, otherwise the
+        invalid_shape protocol error is raised.
+
+        This is similar to the wl_pointer.set_cursor and
+        zwp_tablet_tool_v2.set_cursor requests, but this request accepts a
+        shape instead of contents in the form of a surface. Clients can mix
+        set_cursor and set_shape requests.
+
+        The serial parameter must match the latest wl_pointer.enter or
+        zwp_tablet_tool_v2.proximity_in serial number sent to the client.
+        Otherwise the request will be ignored.
+      </description>
+      <arg name="serial" type="uint" summary="serial number of the enter event"/>
+      <arg name="shape" type="uint" enum="shape"/>
+    </request>
+  </interface>
+</protocol>

--- a/deps/wayland/tablet-v2.xml
+++ b/deps/wayland/tablet-v2.xml
@@ -1,0 +1,1297 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="tablet_v2">
+
+  <copyright>
+    Copyright 2014 © Stephen "Lyude" Chandler Paul
+    Copyright 2015-2024 © Red Hat, Inc.
+
+    Permission is hereby granted, free of charge, to any person
+    obtaining a copy of this software and associated documentation files
+    (the "Software"), to deal in the Software without restriction,
+    including without limitation the rights to use, copy, modify, merge,
+    publish, distribute, sublicense, and/or sell copies of the Software,
+    and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the
+    next paragraph) shall be included in all copies or substantial
+    portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+    BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+    ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+  </copyright>
+
+  <description summary="Wayland protocol for graphics tablets">
+    This description provides a high-level overview of the interplay between
+    the interfaces defined this protocol. For details, see the protocol
+    specification.
+
+    More than one tablet may exist, and device-specifics matter. Tablets are
+    not represented by a single virtual device like wl_pointer. A client
+    binds to the tablet manager object which is just a proxy object. From
+    that, the client requests wp_tablet_manager.get_tablet_seat(wl_seat)
+    and that returns the actual interface that has all the tablets. With
+    this indirection, we can avoid merging wp_tablet into the actual Wayland
+    protocol, a long-term benefit.
+
+    The wp_tablet_seat sends a "tablet added" event for each tablet
+    connected. That event is followed by descriptive events about the
+    hardware; currently that includes events for name, vid/pid and
+    a wp_tablet.path event that describes a local path. This path can be
+    used to uniquely identify a tablet or get more information through
+    libwacom. Emulated or nested tablets can skip any of those, e.g. a
+    virtual tablet may not have a vid/pid. The sequence of descriptive
+    events is terminated by a wp_tablet.done event to signal that a client
+    may now finalize any initialization for that tablet.
+
+    Events from tablets require a tool in proximity. Tools are also managed
+    by the tablet seat; a "tool added" event is sent whenever a tool is new
+    to the compositor. That event is followed by a number of descriptive
+    events about the hardware; currently that includes capabilities,
+    hardware id and serial number, and tool type. Similar to the tablet
+    interface, a wp_tablet_tool.done event is sent to terminate that initial
+    sequence.
+
+    Any event from a tool happens on the wp_tablet_tool interface. When the
+    tool gets into proximity of the tablet, a proximity_in event is sent on
+    the wp_tablet_tool interface, listing the tablet and the surface. That
+    event is followed by a motion event with the coordinates. After that,
+    it's the usual motion, axis, button, etc. events. The protocol's
+    serialisation means events are grouped by wp_tablet_tool.frame events.
+
+    Two special events (that don't exist in X) are down and up. They signal
+    "tip touching the surface". For tablets without real proximity
+    detection, the sequence is: proximity_in, motion, down, frame.
+
+    When the tool leaves proximity, a proximity_out event is sent. If any
+    button is still down, a button release event is sent before this
+    proximity event. These button events are sent in the same frame as the
+    proximity event to signal to the client that the buttons were held when
+    the tool left proximity.
+
+    If the tool moves out of the surface but stays in proximity (i.e.
+    between windows), compositor-specific grab policies apply. This usually
+    means that the proximity-out is delayed until all buttons are released.
+
+    Moving a tool physically from one tablet to the other has no real effect
+    on the protocol, since we already have the tool object from the "tool
+    added" event. All the information is already there and the proximity
+    events on both tablets are all a client needs to reconstruct what
+    happened.
+
+    Some extra axes are normalized, i.e. the client knows the range as
+    specified in the protocol (e.g. [0, 65535]), the granularity however is
+    unknown. The current normalized axes are pressure, distance, and slider.
+
+    Other extra axes are in physical units as specified in the protocol.
+    The current extra axes with physical units are tilt, rotation and
+    wheel rotation.
+
+    Since tablets work independently of the pointer controlled by the mouse,
+    the focus handling is independent too and controlled by proximity.
+    The wp_tablet_tool.set_cursor request sets a tool-specific cursor.
+    This cursor surface may be the same as the mouse cursor, and it may be
+    the same across tools but it is possible to be more fine-grained. For
+    example, a client may set different cursors for the pen and eraser.
+
+    Tools are generally independent of tablets and it is
+    compositor-specific policy when a tool can be removed. Common approaches
+    will likely include some form of removing a tool when all tablets the
+    tool was used on are removed.
+  </description>
+
+  <interface name="zwp_tablet_manager_v2" version="2">
+    <description summary="controller object for graphic tablet devices">
+      An object that provides access to the graphics tablets available on this
+      system. All tablets are associated with a seat, to get access to the
+      actual tablets, use wp_tablet_manager.get_tablet_seat.
+    </description>
+
+    <request name="get_tablet_seat">
+      <description summary="get the tablet seat">
+	Get the wp_tablet_seat object for the given seat. This object
+	provides access to all graphics tablets in this seat.
+      </description>
+      <arg name="tablet_seat" type="new_id" interface="zwp_tablet_seat_v2"/>
+      <arg name="seat" type="object" interface="wl_seat" summary="The wl_seat object to retrieve the tablets for" />
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="release the memory for the tablet manager object">
+	Destroy the wp_tablet_manager object. Objects created from this
+	object are unaffected and should be destroyed separately.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwp_tablet_seat_v2" version="2">
+    <description summary="controller object for graphic tablet devices of a seat">
+      An object that provides access to the graphics tablets available on this
+      seat. After binding to this interface, the compositor sends a set of
+      wp_tablet_seat.tablet_added and wp_tablet_seat.tool_added events.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="release the memory for the tablet seat object">
+	Destroy the wp_tablet_seat object. Objects created from this
+	object are unaffected and should be destroyed separately.
+      </description>
+    </request>
+
+    <event name="tablet_added">
+      <description summary="new device notification">
+	This event is sent whenever a new tablet becomes available on this
+	seat. This event only provides the object id of the tablet, any
+	static information about the tablet (device name, vid/pid, etc.) is
+	sent through the wp_tablet interface.
+      </description>
+      <arg name="id" type="new_id" interface="zwp_tablet_v2" summary="the newly added graphics tablet"/>
+    </event>
+
+    <event name="tool_added">
+      <description summary="a new tool has been used with a tablet">
+	This event is sent whenever a tool that has not previously been used
+	with a tablet comes into use. This event only provides the object id
+	of the tool; any static information about the tool (capabilities,
+	type, etc.) is sent through the wp_tablet_tool interface.
+      </description>
+      <arg name="id" type="new_id" interface="zwp_tablet_tool_v2" summary="the newly added tablet tool"/>
+    </event>
+
+    <event name="pad_added">
+      <description summary="new pad notification">
+	This event is sent whenever a new pad is known to the system. Typically,
+	pads are physically attached to tablets and a pad_added event is
+	sent immediately after the wp_tablet_seat.tablet_added.
+	However, some standalone pad devices logically attach to tablets at
+	runtime, and the client must wait for wp_tablet_pad.enter to know
+	the tablet a pad is attached to.
+
+	This event only provides the object id of the pad. All further
+	features (buttons, strips, rings) are sent through the wp_tablet_pad
+	interface.
+      </description>
+      <arg name="id" type="new_id" interface="zwp_tablet_pad_v2" summary="the newly added pad"/>
+    </event>
+  </interface>
+
+  <interface name="zwp_tablet_tool_v2" version="2">
+    <description summary="a physical tablet tool">
+      An object that represents a physical tool that has been, or is
+      currently in use with a tablet in this seat. Each wp_tablet_tool
+      object stays valid until the client destroys it; the compositor
+      reuses the wp_tablet_tool object to indicate that the object's
+      respective physical tool has come into proximity of a tablet again.
+
+      A wp_tablet_tool object's relation to a physical tool depends on the
+      tablet's ability to report serial numbers. If the tablet supports
+      this capability, then the object represents a specific physical tool
+      and can be identified even when used on multiple tablets.
+
+      A tablet tool has a number of static characteristics, e.g. tool type,
+      hardware_serial and capabilities. These capabilities are sent in an
+      event sequence after the wp_tablet_seat.tool_added event before any
+      actual events from this tool. This initial event sequence is
+      terminated by a wp_tablet_tool.done event.
+
+      Tablet tool events are grouped by wp_tablet_tool.frame events.
+      Any events received before a wp_tablet_tool.frame event should be
+      considered part of the same hardware state change.
+    </description>
+
+    <request name="set_cursor">
+      <description summary="set the tablet tool's surface">
+	Sets the surface of the cursor used for this tool on the given
+	tablet. This request only takes effect if the tool is in proximity
+	of one of the requesting client's surfaces or the surface parameter
+	is the current pointer surface. If there was a previous surface set
+	with this request it is replaced. If surface is NULL, the cursor
+	image is hidden.
+
+	The parameters hotspot_x and hotspot_y define the position of the
+	pointer surface relative to the pointer location. Its top-left corner
+	is always at (x, y) - (hotspot_x, hotspot_y), where (x, y) are the
+	coordinates of the pointer location, in surface-local coordinates.
+
+	On surface.attach requests to the pointer surface, hotspot_x and
+	hotspot_y are decremented by the x and y parameters passed to the
+	request. Attach must be confirmed by wl_surface.commit as usual.
+
+	The hotspot can also be updated by passing the currently set pointer
+	surface to this request with new values for hotspot_x and hotspot_y.
+
+	The current and pending input regions of the wl_surface are cleared,
+	and wl_surface.set_input_region is ignored until the wl_surface is no
+	longer used as the cursor. When the use as a cursor ends, the current
+	and pending input regions become undefined, and the wl_surface is
+	unmapped.
+
+	This request gives the surface the role of a wp_tablet_tool cursor. A
+	surface may only ever be used as the cursor surface for one
+	wp_tablet_tool. If the surface already has another role or has
+	previously been used as cursor surface for a different tool, a
+	protocol error is raised.
+      </description>
+      <arg name="serial" type="uint" summary="serial of the proximity_in event"/>
+      <arg name="surface" type="object" interface="wl_surface" allow-null="true"/>
+      <arg name="hotspot_x" type="int" summary="surface-local x coordinate"/>
+      <arg name="hotspot_y" type="int" summary="surface-local y coordinate"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the tool object">
+	This destroys the client's resource for this tool object.
+      </description>
+    </request>
+
+    <enum name="type">
+      <description summary="a physical tool type">
+	Describes the physical type of a tool. The physical type of a tool
+	generally defines its base usage.
+
+	The mouse tool represents a mouse-shaped tool that is not a relative
+	device but bound to the tablet's surface, providing absolute
+	coordinates.
+
+	The lens tool is a mouse-shaped tool with an attached lens to
+	provide precision focus.
+      </description>
+      <entry name="pen" value="0x140" summary="Pen"/>
+      <entry name="eraser" value="0x141" summary="Eraser"/>
+      <entry name="brush" value="0x142" summary="Brush"/>
+      <entry name="pencil" value="0x143" summary="Pencil"/>
+      <entry name="airbrush" value="0x144" summary="Airbrush"/>
+      <entry name="finger" value="0x145" summary="Finger"/>
+      <entry name="mouse" value="0x146" summary="Mouse"/>
+      <entry name="lens" value="0x147" summary="Lens"/>
+    </enum>
+
+    <event name="type">
+      <description summary="tool type">
+	The tool type is the high-level type of the tool and usually decides
+	the interaction expected from this tool.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet_tool.done event.
+      </description>
+      <arg name="tool_type" type="uint" enum="type" summary="the physical tool type"/>
+    </event>
+
+    <event name="hardware_serial">
+      <description summary="unique hardware serial number of the tool">
+	If the physical tool can be identified by a unique 64-bit serial
+	number, this event notifies the client of this serial number.
+
+	If multiple tablets are available in the same seat and the tool is
+	uniquely identifiable by the serial number, that tool may move
+	between tablets.
+
+	Otherwise, if the tool has no serial number and this event is
+	missing, the tool is tied to the tablet it first comes into
+	proximity with. Even if the physical tool is used on multiple
+	tablets, separate wp_tablet_tool objects will be created, one per
+	tablet.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet_tool.done event.
+      </description>
+      <arg name="hardware_serial_hi" type="uint" summary="the unique serial number of the tool, most significant bits"/>
+      <arg name="hardware_serial_lo" type="uint" summary="the unique serial number of the tool, least significant bits"/>
+    </event>
+
+    <event name="hardware_id_wacom">
+      <description summary="hardware id notification in Wacom's format">
+	This event notifies the client of a hardware id available on this tool.
+
+	The hardware id is a device-specific 64-bit id that provides extra
+	information about the tool in use, beyond the wl_tool.type
+	enumeration. The format of the id is specific to tablets made by
+	Wacom Inc. For example, the hardware id of a Wacom Grip
+	Pen (a stylus) is 0x802.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet_tool.done event.
+      </description>
+      <arg name="hardware_id_hi" type="uint" summary="the hardware id, most significant bits"/>
+      <arg name="hardware_id_lo" type="uint" summary="the hardware id, least significant bits"/>
+    </event>
+
+    <enum name="capability">
+      <description summary="capability flags for a tool">
+	Describes extra capabilities on a tablet.
+
+	Any tool must provide x and y values, extra axes are
+	device-specific.
+      </description>
+      <entry name="tilt" value="1" summary="Tilt axes"/>
+      <entry name="pressure" value="2" summary="Pressure axis"/>
+      <entry name="distance" value="3" summary="Distance axis"/>
+      <entry name="rotation" value="4" summary="Z-rotation axis"/>
+      <entry name="slider" value="5" summary="Slider axis"/>
+      <entry name="wheel" value="6" summary="Wheel axis"/>
+    </enum>
+
+    <event name="capability">
+      <description summary="tool capability notification">
+	This event notifies the client of any capabilities of this tool,
+	beyond the main set of x/y axes and tip up/down detection.
+
+	One event is sent for each extra capability available on this tool.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet_tool.done event.
+      </description>
+      <arg name="capability" type="uint" enum="capability" summary="the capability"/>
+    </event>
+
+    <event name="done">
+      <description summary="tool description events sequence complete">
+	This event signals the end of the initial burst of descriptive
+	events. A client may consider the static description of the tool to
+	be complete and finalize initialization of the tool.
+      </description>
+    </event>
+
+    <event name="removed">
+      <description summary="tool removed">
+	This event is sent when the tool is removed from the system and will
+	send no further events. Should the physical tool come back into
+	proximity later, a new wp_tablet_tool object will be created.
+
+	It is compositor-dependent when a tool is removed. A compositor may
+	remove a tool on proximity out, tablet removal or any other reason.
+	A compositor may also keep a tool alive until shutdown.
+
+	If the tool is currently in proximity, a proximity_out event will be
+	sent before the removed event. See wp_tablet_tool.proximity_out for
+	the handling of any buttons logically down.
+
+	When this event is received, the client must wp_tablet_tool.destroy
+	the object.
+      </description>
+    </event>
+
+    <event name="proximity_in">
+      <description summary="proximity in event">
+	Notification that this tool is focused on a certain surface.
+
+	This event can be received when the tool has moved from one surface to
+	another, or when the tool has come back into proximity above the
+	surface.
+
+	If any button is logically down when the tool comes into proximity,
+	the respective button event is sent after the proximity_in event but
+	within the same frame as the proximity_in event.
+      </description>
+      <arg name="serial" type="uint"/>
+      <arg name="tablet" type="object" interface="zwp_tablet_v2" summary="The tablet the tool is in proximity of"/>
+      <arg name="surface" type="object" interface="wl_surface" summary="The current surface the tablet tool is over"/>
+    </event>
+
+    <event name="proximity_out">
+      <description summary="proximity out event">
+	Notification that this tool has either left proximity, or is no
+	longer focused on a certain surface.
+
+	When the tablet tool leaves proximity of the tablet, button release
+	events are sent for each button that was held down at the time of
+	leaving proximity. These events are sent before the proximity_out
+	event but within the same wp_tablet.frame.
+
+	If the tool stays within proximity of the tablet, but the focus
+	changes from one surface to another, a button release event may not
+	be sent until the button is actually released or the tool leaves the
+	proximity of the tablet.
+      </description>
+    </event>
+
+    <event name="down">
+      <description summary="tablet tool is making contact">
+	Sent whenever the tablet tool comes in contact with the surface of the
+	tablet.
+
+	If the tool is already in contact with the tablet when entering the
+	input region, the client owning said region will receive a
+	wp_tablet.proximity_in event, followed by a wp_tablet.down
+	event and a wp_tablet.frame event.
+
+	Note that this event describes logical contact, not physical
+	contact. On some devices, a compositor may not consider a tool in
+	logical contact until a minimum physical pressure threshold is
+	exceeded.
+      </description>
+      <arg name="serial" type="uint"/>
+    </event>
+
+    <event name="up">
+      <description summary="tablet tool is no longer making contact">
+	Sent whenever the tablet tool stops making contact with the surface of
+	the tablet, or when the tablet tool moves out of the input region
+	and the compositor grab (if any) is dismissed.
+
+	If the tablet tool moves out of the input region while in contact
+	with the surface of the tablet and the compositor does not have an
+	ongoing grab on the surface, the client owning said region will
+	receive a wp_tablet.up event, followed by a wp_tablet.proximity_out
+	event and a wp_tablet.frame event. If the compositor has an ongoing
+	grab on this device, this event sequence is sent whenever the grab
+	is dismissed in the future.
+
+	Note that this event describes logical contact, not physical
+	contact. On some devices, a compositor may not consider a tool out
+	of logical contact until physical pressure falls below a specific
+	threshold.
+      </description>
+    </event>
+
+    <event name="motion">
+      <description summary="motion event">
+	Sent whenever a tablet tool moves.
+      </description>
+      <arg name="x" type="fixed" summary="surface-local x coordinate"/>
+      <arg name="y" type="fixed" summary="surface-local y coordinate"/>
+    </event>
+
+    <event name="pressure">
+      <description summary="pressure change event">
+	Sent whenever the pressure axis on a tool changes. The value of this
+	event is normalized to a value between 0 and 65535.
+
+	Note that pressure may be nonzero even when a tool is not in logical
+	contact. See the down and up events for more details.
+      </description>
+      <arg name="pressure" type="uint" summary="The current pressure value"/>
+    </event>
+
+    <event name="distance">
+      <description summary="distance change event">
+	Sent whenever the distance axis on a tool changes. The value of this
+	event is normalized to a value between 0 and 65535.
+
+	Note that distance may be nonzero even when a tool is not in logical
+	contact. See the down and up events for more details.
+      </description>
+      <arg name="distance" type="uint" summary="The current distance value"/>
+    </event>
+
+    <event name="tilt">
+      <description summary="tilt change event">
+	Sent whenever one or both of the tilt axes on a tool change. Each tilt
+	value is in degrees, relative to the z-axis of the tablet.
+	The angle is positive when the top of a tool tilts along the
+	positive x or y axis.
+      </description>
+      <arg name="tilt_x" type="fixed" summary="The current value of the X tilt axis"/>
+      <arg name="tilt_y" type="fixed" summary="The current value of the Y tilt axis"/>
+    </event>
+
+    <event name="rotation">
+      <description summary="z-rotation change event">
+	Sent whenever the z-rotation axis on the tool changes. The
+	rotation value is in degrees clockwise from the tool's
+	logical neutral position.
+      </description>
+      <arg name="degrees" type="fixed" summary="The current rotation of the Z axis"/>
+    </event>
+
+    <event name="slider">
+      <description summary="Slider position change event">
+	Sent whenever the slider position on the tool changes. The
+	value is normalized between -65535 and 65535, with 0 as the logical
+	neutral position of the slider.
+
+	The slider is available on e.g. the Wacom Airbrush tool.
+      </description>
+      <arg name="position" type="int" summary="The current position of slider"/>
+    </event>
+
+    <event name="wheel">
+      <description summary="Wheel delta event">
+	Sent whenever the wheel on the tool emits an event. This event
+	contains two values for the same axis change. The degrees value is
+	in the same orientation as the wl_pointer.vertical_scroll axis. The
+	clicks value is in discrete logical clicks of the mouse wheel. This
+	value may be zero if the movement of the wheel was less
+	than one logical click.
+
+	Clients should choose either value and avoid mixing degrees and
+	clicks. The compositor may accumulate values smaller than a logical
+	click and emulate click events when a certain threshold is met.
+	Thus, wl_tablet_tool.wheel events with non-zero clicks values may
+	have different degrees values.
+      </description>
+      <arg name="degrees" type="fixed" summary="The wheel delta in degrees"/>
+      <arg name="clicks" type="int" summary="The wheel delta in discrete clicks"/>
+    </event>
+
+    <enum name="button_state">
+      <description summary="physical button state">
+	Describes the physical state of a button that produced the button event.
+      </description>
+      <entry name="released" value="0" summary="button is not pressed"/>
+      <entry name="pressed" value="1" summary="button is pressed"/>
+    </enum>
+
+    <event name="button">
+      <description summary="button event">
+	Sent whenever a button on the tool is pressed or released.
+
+	If a button is held down when the tool moves in or out of proximity,
+	button events are generated by the compositor. See
+	wp_tablet_tool.proximity_in and wp_tablet_tool.proximity_out for
+	details.
+      </description>
+      <arg name="serial" type="uint"/>
+      <arg name="button" type="uint" summary="The button whose state has changed"/>
+      <arg name="state" type="uint" enum="button_state" summary="Whether the button was pressed or released"/>
+    </event>
+
+    <event name="frame">
+      <description summary="frame event">
+	Marks the end of a series of axis and/or button updates from the
+	tablet. The Wayland protocol requires axis updates to be sent
+	sequentially, however all events within a frame should be considered
+	one hardware event.
+      </description>
+      <arg name="time" type="uint" summary="The time of the event with millisecond granularity"/>
+    </event>
+
+    <enum name="error">
+      <entry name="role" value="0" summary="given wl_surface has another role"/>
+    </enum>
+  </interface>
+
+  <interface name="zwp_tablet_v2" version="2">
+    <description summary="graphics tablet device">
+      The wp_tablet interface represents one graphics tablet device. The
+      tablet interface itself does not generate events; all events are
+      generated by wp_tablet_tool objects when in proximity above a tablet.
+
+      A tablet has a number of static characteristics, e.g. device name and
+      pid/vid. These capabilities are sent in an event sequence after the
+      wp_tablet_seat.tablet_added event. This initial event sequence is
+      terminated by a wp_tablet.done event.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the tablet object">
+	This destroys the client's resource for this tablet object.
+      </description>
+    </request>
+
+    <event name="name">
+      <description summary="tablet device name">
+        A descriptive name for the tablet device.
+
+	If the device has no descriptive name, this event is not sent.
+
+	This event is sent in the initial burst of events before the
+        wp_tablet.done event.
+      </description>
+      <arg name="name" type="string" summary="the device name"/>
+    </event>
+
+    <event name="id">
+      <description summary="tablet device vendor/product id">
+	The vendor and product IDs for the tablet device.
+
+	The interpretation of the id depends on the wp_tablet.bustype.
+	Prior to version v2 of this protocol, the id was implied to be a USB
+	vendor and product ID. If no wp_tablet.bustype is sent, the ID
+	is to be interpreted as USB vendor and product ID.
+
+	If the device has no vendor/product ID, this event is not sent.
+	This can happen for virtual devices or non-USB devices, for instance.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet.done event.
+      </description>
+      <arg name="vid" type="uint" summary="vendor id"/>
+      <arg name="pid" type="uint" summary="product id"/>
+    </event>
+
+    <event name="path">
+      <description summary="path to the device">
+	A system-specific device path that indicates which device is behind
+	this wp_tablet. This information may be used to gather additional
+	information about the device, e.g. through libwacom.
+
+	A device may have more than one device path. If so, multiple
+	wp_tablet.path events are sent. A device may be emulated and not
+	have a device path, and in that case this event will not be sent.
+
+	The format of the path is unspecified, it may be a device node, a
+	sysfs path, or some other identifier. It is up to the client to
+	identify the string provided.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet.done event.
+      </description>
+      <arg name="path" type="string" summary="path to local device"/>
+    </event>
+
+    <event name="done">
+      <description summary="tablet description events sequence complete">
+	This event is sent immediately to signal the end of the initial
+	burst of descriptive events. A client may consider the static
+	description of the tablet to be complete and finalize initialization
+	of the tablet.
+      </description>
+    </event>
+
+    <event name="removed">
+      <description summary="tablet removed event">
+	Sent when the tablet has been removed from the system. When a tablet
+	is removed, some tools may be removed.
+
+	When this event is received, the client must wp_tablet.destroy
+	the object.
+      </description>
+    </event>
+
+    <!-- Version 2 additions -->
+
+    <enum name="bustype" since="2">
+      <description summary="bus type ">
+	Describes the bus types this tablet is connected to.
+      </description>
+      <entry name="usb" value="3" summary="USB"/>
+      <entry name="bluetooth" value="5" summary="Bluetooth"/>
+      <entry name="virtual" value="6" summary="Virtual"/>
+      <entry name="serial" value="17" summary="Serial"/>
+      <entry name="i2c" value="24" summary="I2C"/>
+    </enum>
+
+    <event name="bustype" since="2">
+      <description summary="tablet device bus type">
+	The bustype argument is one of the BUS_ defines in the Linux kernel's
+	linux/input.h
+
+	If the device has no known bustype or the bustype cannot be
+	queried, this event is not sent.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet.done event.
+      </description>
+      <arg name="bustype" type="uint" enum="bustype" summary="bus type"/>
+    </event>
+  </interface>
+
+  <interface name="zwp_tablet_pad_ring_v2" version="2">
+    <description summary="pad ring">
+      A circular interaction area, such as the touch ring on the Wacom Intuos
+      Pro series tablets.
+
+      Events on a ring are logically grouped by the wl_tablet_pad_ring.frame
+      event.
+    </description>
+
+    <request name="set_feedback">
+      <description summary="set compositor feedback">
+	Request that the compositor use the provided feedback string
+	associated with this ring. This request should be issued immediately
+	after a wp_tablet_pad_group.mode_switch event from the corresponding
+	group is received, or whenever the ring is mapped to a different
+	action. See wp_tablet_pad_group.mode_switch for more details.
+
+	Clients are encouraged to provide context-aware descriptions for
+	the actions associated with the ring; compositors may use this
+	information to offer visual feedback about the button layout
+	(eg. on-screen displays).
+
+	The provided string 'description' is a UTF-8 encoded string to be
+	associated with this ring, and is considered user-visible; general
+	internationalization rules apply.
+
+	The serial argument will be that of the last
+	wp_tablet_pad_group.mode_switch event received for the group of this
+	ring. Requests providing other serials than the most recent one will be
+	ignored.
+      </description>
+      <arg name="description" type="string" summary="ring description"/>
+      <arg name="serial" type="uint" summary="serial of the mode switch event"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the ring object">
+	This destroys the client's resource for this ring object.
+      </description>
+    </request>
+
+    <enum name="source">
+      <description summary="ring axis source">
+	Describes the source types for ring events. This indicates to the
+	client how a ring event was physically generated; a client may
+	adjust the user interface accordingly. For example, events
+	from a "finger" source may trigger kinetic scrolling.
+      </description>
+      <entry name="finger" value="1" summary="finger"/>
+    </enum>
+
+    <event name="source">
+      <description summary="ring event source">
+	Source information for ring events.
+
+	This event does not occur on its own. It is sent before a
+	wp_tablet_pad_ring.frame event and carries the source information
+	for all events within that frame.
+
+	The source specifies how this event was generated. If the source is
+	wp_tablet_pad_ring.source.finger, a wp_tablet_pad_ring.stop event
+	will be sent when the user lifts the finger off the device.
+
+	This event is optional. If the source is unknown for an interaction,
+	no event is sent.
+      </description>
+      <arg name="source" type="uint" enum="source" summary="the event source"/>
+    </event>
+
+    <event name="angle">
+      <description summary="angle changed">
+	Sent whenever the angle on a ring changes.
+
+	The angle is provided in degrees clockwise from the logical
+	north of the ring in the pad's current rotation.
+      </description>
+      <arg name="degrees" type="fixed" summary="the current angle in degrees"/>
+    </event>
+
+    <event name="stop">
+      <description summary="interaction stopped">
+	Stop notification for ring events.
+
+	For some wp_tablet_pad_ring.source types, a wp_tablet_pad_ring.stop
+	event is sent to notify a client that the interaction with the ring
+	has terminated. This enables the client to implement kinetic scrolling.
+	See the wp_tablet_pad_ring.source documentation for information on
+	when this event may be generated.
+
+	Any wp_tablet_pad_ring.angle events with the same source after this
+	event should be considered as the start of a new interaction.
+      </description>
+    </event>
+
+    <event name="frame">
+      <description summary="end of a ring event sequence">
+	Indicates the end of a set of ring events that logically belong
+	together. A client is expected to accumulate the data in all events
+	within the frame before proceeding.
+
+	All wp_tablet_pad_ring events before a wp_tablet_pad_ring.frame event belong
+	logically together. For example, on termination of a finger interaction
+	on a ring the compositor will send a wp_tablet_pad_ring.source event,
+	a wp_tablet_pad_ring.stop event and a wp_tablet_pad_ring.frame event.
+
+	A wp_tablet_pad_ring.frame event is sent for every logical event
+	group, even if the group only contains a single wp_tablet_pad_ring
+	event. Specifically, a client may get a sequence: angle, frame,
+	angle, frame, etc.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+    </event>
+  </interface>
+
+  <interface name="zwp_tablet_pad_strip_v2" version="2">
+    <description summary="pad strip">
+      A linear interaction area, such as the strips found in Wacom Cintiq
+      models.
+
+      Events on a strip are logically grouped by the wl_tablet_pad_strip.frame
+      event.
+    </description>
+
+    <request name="set_feedback">
+      <description summary="set compositor feedback">
+	Requests the compositor to use the provided feedback string
+	associated with this strip. This request should be issued immediately
+	after a wp_tablet_pad_group.mode_switch event from the corresponding
+	group is received, or whenever the strip is mapped to a different
+	action. See wp_tablet_pad_group.mode_switch for more details.
+
+	Clients are encouraged to provide context-aware descriptions for
+	the actions associated with the strip, and compositors may use this
+	information to offer visual feedback about the button layout
+	(eg. on-screen displays).
+
+	The provided string 'description' is a UTF-8 encoded string to be
+	associated with this ring, and is considered user-visible; general
+	internationalization rules apply.
+
+	The serial argument will be that of the last
+	wp_tablet_pad_group.mode_switch event received for the group of this
+	strip. Requests providing other serials than the most recent one will be
+	ignored.
+      </description>
+      <arg name="description" type="string" summary="strip description"/>
+      <arg name="serial" type="uint" summary="serial of the mode switch event"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the strip object">
+	This destroys the client's resource for this strip object.
+      </description>
+    </request>
+
+    <enum name="source">
+      <description summary="strip axis source">
+	Describes the source types for strip events. This indicates to the
+	client how a strip event was physically generated; a client may
+	adjust the user interface accordingly. For example, events
+	from a "finger" source may trigger kinetic scrolling.
+      </description>
+      <entry name="finger" value="1" summary="finger"/>
+    </enum>
+
+    <event name="source">
+      <description summary="strip event source">
+	Source information for strip events.
+
+	This event does not occur on its own. It is sent before a
+	wp_tablet_pad_strip.frame event and carries the source information
+	for all events within that frame.
+
+	The source specifies how this event was generated. If the source is
+	wp_tablet_pad_strip.source.finger, a wp_tablet_pad_strip.stop event
+	will be sent when the user lifts their finger off the device.
+
+	This event is optional. If the source is unknown for an interaction,
+	no event is sent.
+      </description>
+      <arg name="source" type="uint" enum="source" summary="the event source"/>
+    </event>
+
+    <event name="position">
+      <description summary="position changed">
+	Sent whenever the position on a strip changes.
+
+	The position is normalized to a range of [0, 65535], the 0-value
+	represents the top-most and/or left-most position of the strip in
+	the pad's current rotation.
+      </description>
+      <arg name="position" type="uint" summary="the current position"/>
+    </event>
+
+    <event name="stop">
+      <description summary="interaction stopped">
+	Stop notification for strip events.
+
+	For some wp_tablet_pad_strip.source types, a wp_tablet_pad_strip.stop
+	event is sent to notify a client that the interaction with the strip
+	has terminated. This enables the client to implement kinetic
+	scrolling. See the wp_tablet_pad_strip.source documentation for
+	information on when this event may be generated.
+
+	Any wp_tablet_pad_strip.position events with the same source after this
+	event should be considered as the start of a new interaction.
+      </description>
+    </event>
+
+    <event name="frame">
+      <description summary="end of a strip event sequence">
+	Indicates the end of a set of events that represent one logical
+	hardware strip event. A client is expected to accumulate the data
+	in all events within the frame before proceeding.
+
+	All wp_tablet_pad_strip events before a wp_tablet_pad_strip.frame event belong
+	logically together. For example, on termination of a finger interaction
+	on a strip the compositor will send a wp_tablet_pad_strip.source event,
+	a wp_tablet_pad_strip.stop event and a wp_tablet_pad_strip.frame
+	event.
+
+	A wp_tablet_pad_strip.frame event is sent for every logical event
+	group, even if the group only contains a single wp_tablet_pad_strip
+	event. Specifically, a client may get a sequence: position, frame,
+	position, frame, etc.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+    </event>
+  </interface>
+
+  <interface name="zwp_tablet_pad_group_v2" version="2">
+    <description summary="a set of buttons, rings and strips">
+      A pad group describes a distinct (sub)set of buttons, rings and strips
+      present in the tablet. The criteria of this grouping is usually positional,
+      eg. if a tablet has buttons on the left and right side, 2 groups will be
+      presented. The physical arrangement of groups is undisclosed and may
+      change on the fly.
+
+      Pad groups will announce their features during pad initialization. Between
+      the corresponding wp_tablet_pad.group event and wp_tablet_pad_group.done, the
+      pad group will announce the buttons, rings and strips contained in it,
+      plus the number of supported modes.
+
+      Modes are a mechanism to allow multiple groups of actions for every element
+      in the pad group. The number of groups and available modes in each is
+      persistent across device plugs. The current mode is user-switchable, it
+      will be announced through the wp_tablet_pad_group.mode_switch event both
+      whenever it is switched, and after wp_tablet_pad.enter.
+
+      The current mode logically applies to all elements in the pad group,
+      although it is at clients' discretion whether to actually perform different
+      actions, and/or issue the respective .set_feedback requests to notify the
+      compositor. See the wp_tablet_pad_group.mode_switch event for more details.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the pad object">
+	Destroy the wp_tablet_pad_group object. Objects created from this object
+	are unaffected and should be destroyed separately.
+      </description>
+    </request>
+
+    <event name="buttons">
+      <description summary="buttons announced">
+	Sent on wp_tablet_pad_group initialization to announce the available
+	buttons in the group. Button indices start at 0, a button may only be
+	in one group at a time.
+
+	This event is first sent in the initial burst of events before the
+	wp_tablet_pad_group.done event.
+
+	Some buttons are reserved by the compositor. These buttons may not be
+	assigned to any wp_tablet_pad_group. Compositors may broadcast this
+	event in the case of changes to the mapping of these reserved buttons.
+	If the compositor happens to reserve all buttons in a group, this event
+	will be sent with an empty array.
+      </description>
+      <arg name="buttons" type="array" summary="buttons in this group"/>
+    </event>
+
+    <event name="ring">
+      <description summary="ring announced">
+	Sent on wp_tablet_pad_group initialization to announce available rings.
+	One event is sent for each ring available on this pad group.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet_pad_group.done event.
+      </description>
+      <arg name="ring" type="new_id" interface="zwp_tablet_pad_ring_v2"/>
+    </event>
+
+    <event name="strip">
+      <description summary="strip announced">
+	Sent on wp_tablet_pad initialization to announce available strips.
+	One event is sent for each strip available on this pad group.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet_pad_group.done event.
+      </description>
+      <arg name="strip" type="new_id" interface="zwp_tablet_pad_strip_v2"/>
+    </event>
+
+    <event name="modes">
+      <description summary="mode-switch ability announced">
+	Sent on wp_tablet_pad_group initialization to announce that the pad
+	group may switch between modes. A client may use a mode to store a
+	specific configuration for buttons, rings and strips and use the
+	wl_tablet_pad_group.mode_switch event to toggle between these
+	configurations. Mode indices start at 0.
+
+	Switching modes is compositor-dependent. See the
+	wp_tablet_pad_group.mode_switch event for more details.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet_pad_group.done event. This event is only sent when more than
+	more than one mode is available.
+      </description>
+      <arg name="modes" type="uint" summary="the number of modes"/>
+    </event>
+
+    <event name="done">
+      <description summary="tablet group description events sequence complete">
+	This event is sent immediately to signal the end of the initial
+	burst of descriptive events. A client may consider the static
+	description of the tablet to be complete and finalize initialization
+	of the tablet group.
+      </description>
+    </event>
+
+    <event name="mode_switch">
+      <description summary="mode switch event">
+	Notification that the mode was switched.
+
+	A mode applies to all buttons, rings, strips and dials in a group
+	simultaneously, but a client is not required to assign different actions
+	for each mode. For example, a client may have mode-specific button
+	mappings but map the ring to vertical scrolling in all modes. Mode
+	indices start at 0.
+
+	Switching modes is compositor-dependent. The compositor may provide
+	visual cues to the user about the mode, e.g. by toggling LEDs on
+	the tablet device. Mode-switching may be software-controlled or
+	controlled by one or more physical buttons. For example, on a Wacom
+	Intuos Pro, the button inside the ring may be assigned to switch
+	between modes.
+
+	The compositor will also send this event after wp_tablet_pad.enter on
+	each group in order to notify of the current mode. Groups that only
+	feature one mode will use mode=0 when emitting this event.
+
+	If a button action in the new mode differs from the action in the
+	previous mode, the client should immediately issue a
+	wp_tablet_pad.set_feedback request for each changed button.
+
+	If a ring, strip or dial action in the new mode differs from the action
+	in the previous mode, the client should immediately issue a
+	wp_tablet_ring.set_feedback, wp_tablet_strip.set_feedback or
+	wp_tablet_dial.set_feedback request for each changed ring, strip or dial.
+      </description>
+      <arg name="time" type="uint" summary="the time of the event with millisecond granularity"/>
+      <arg name="serial" type="uint"/>
+      <arg name="mode" type="uint" summary="the new mode of the pad"/>
+    </event>
+
+    <!-- Version 2 additions -->
+
+    <event name="dial" since="2">
+      <description summary="dial announced">
+	Sent on wp_tablet_pad initialization to announce available dials.
+	One event is sent for each dial available on this pad group.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet_pad_group.done event.
+      </description>
+      <arg name="dial" type="new_id" interface="zwp_tablet_pad_dial_v2"/>
+    </event>
+  </interface>
+
+  <interface name="zwp_tablet_pad_v2" version="2">
+    <description summary="a set of buttons, rings, strips and dials">
+      A pad device is a set of buttons, rings, strips and dials
+      usually physically present on the tablet device itself. Some
+      exceptions exist where the pad device is physically detached, e.g. the
+      Wacom ExpressKey Remote.
+
+      Pad devices have no axes that control the cursor and are generally
+      auxiliary devices to the tool devices used on the tablet surface.
+
+      A pad device has a number of static characteristics, e.g. the number
+      of rings. These capabilities are sent in an event sequence after the
+      wp_tablet_seat.pad_added event before any actual events from this pad.
+      This initial event sequence is terminated by a wp_tablet_pad.done
+      event.
+
+      All pad features (buttons, rings, strips and dials) are logically divided into
+      groups and all pads have at least one group. The available groups are
+      notified through the wp_tablet_pad.group event; the compositor will
+      emit one event per group before emitting wp_tablet_pad.done.
+
+      Groups may have multiple modes. Modes allow clients to map multiple
+      actions to a single pad feature. Only one mode can be active per group,
+      although different groups may have different active modes.
+    </description>
+
+    <request name="set_feedback">
+      <description summary="set compositor feedback">
+	Requests the compositor to use the provided feedback string
+	associated with this button. This request should be issued immediately
+	after a wp_tablet_pad_group.mode_switch event from the corresponding
+	group is received, or whenever a button is mapped to a different
+	action. See wp_tablet_pad_group.mode_switch for more details.
+
+	Clients are encouraged to provide context-aware descriptions for
+	the actions associated with each button, and compositors may use
+	this information to offer visual feedback on the button layout
+	(e.g. on-screen displays).
+
+	Button indices start at 0. Setting the feedback string on a button
+	that is reserved by the compositor (i.e. not belonging to any
+	wp_tablet_pad_group) does not generate an error but the compositor
+	is free to ignore the request.
+
+	The provided string 'description' is a UTF-8 encoded string to be
+	associated with this ring, and is considered user-visible; general
+	internationalization rules apply.
+
+	The serial argument will be that of the last
+	wp_tablet_pad_group.mode_switch event received for the group of this
+	button. Requests providing other serials than the most recent one will
+	be ignored.
+      </description>
+      <arg name="button" type="uint" summary="button index"/>
+      <arg name="description" type="string" summary="button description"/>
+      <arg name="serial" type="uint" summary="serial of the mode switch event"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the pad object">
+	Destroy the wp_tablet_pad object. Objects created from this object
+	are unaffected and should be destroyed separately.
+      </description>
+    </request>
+
+    <event name="group">
+      <description summary="group announced">
+	Sent on wp_tablet_pad initialization to announce available groups.
+	One event is sent for each pad group available.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet_pad.done event. At least one group will be announced.
+      </description>
+      <arg name="pad_group" type="new_id" interface="zwp_tablet_pad_group_v2"/>
+    </event>
+
+    <event name="path">
+      <description summary="path to the device">
+	A system-specific device path that indicates which device is behind
+	this wp_tablet_pad. This information may be used to gather additional
+	information about the device, e.g. through libwacom.
+
+	The format of the path is unspecified, it may be a device node, a
+	sysfs path, or some other identifier. It is up to the client to
+	identify the string provided.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet_pad.done event.
+      </description>
+      <arg name="path" type="string" summary="path to local device"/>
+    </event>
+
+    <event name="buttons">
+      <description summary="buttons announced">
+	Sent on wp_tablet_pad initialization to announce the available
+	buttons.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet_pad.done event. This event is only sent when at least one
+	button is available.
+      </description>
+      <arg name="buttons" type="uint" summary="the number of buttons"/>
+    </event>
+
+    <event name="done">
+      <description summary="pad description event sequence complete">
+	This event signals the end of the initial burst of descriptive
+	events. A client may consider the static description of the pad to
+	be complete and finalize initialization of the pad.
+      </description>
+    </event>
+
+    <enum name="button_state">
+      <description summary="physical button state">
+	Describes the physical state of a button that caused the button
+	event.
+      </description>
+      <entry name="released" value="0" summary="the button is not pressed"/>
+      <entry name="pressed" value="1" summary="the button is pressed"/>
+    </enum>
+
+    <event name="button">
+      <description summary="physical button state">
+	Sent whenever the physical state of a button changes.
+      </description>
+      <arg name="time" type="uint" summary="the time of the event with millisecond granularity"/>
+      <arg name="button" type="uint" summary="the index of the button that changed state"/>
+      <arg name="state" type="uint" enum="button_state"/>
+    </event>
+
+    <event name="enter">
+      <description summary="enter event">
+	Notification that this pad is focused on the specified surface.
+      </description>
+      <arg name="serial" type="uint" summary="serial number of the enter event"/>
+      <arg name="tablet" type="object" interface="zwp_tablet_v2" summary="the tablet the pad is attached to"/>
+      <arg name="surface" type="object" interface="wl_surface" summary="surface the pad is focused on"/>
+    </event>
+
+    <event name="leave">
+      <description summary="leave event">
+	Notification that this pad is no longer focused on the specified
+	surface.
+      </description>
+      <arg name="serial" type="uint" summary="serial number of the leave event"/>
+      <arg name="surface" type="object" interface="wl_surface" summary="surface the pad is no longer focused on"/>
+    </event>
+
+    <event name="removed">
+      <description summary="pad removed event">
+	Sent when the pad has been removed from the system. When a tablet
+	is removed its pad(s) will be removed too.
+
+	When this event is received, the client must destroy all rings, strips
+	and groups that were offered by this pad, and issue wp_tablet_pad.destroy
+	the pad itself.
+      </description>
+    </event>
+  </interface>
+
+  <interface name="zwp_tablet_pad_dial_v2" version="2">
+    <description summary="pad dial">
+      A rotary control, e.g. a dial or a wheel.
+
+      Events on a dial are logically grouped by the wl_tablet_pad_dial.frame
+      event.
+    </description>
+
+    <request name="set_feedback">
+      <description summary="set compositor feedback">
+	Requests the compositor to use the provided feedback string
+	associated with this dial. This request should be issued immediately
+	after a wp_tablet_pad_group.mode_switch event from the corresponding
+	group is received, or whenever the dial is mapped to a different
+	action. See wp_tablet_pad_group.mode_switch for more details.
+
+	Clients are encouraged to provide context-aware descriptions for
+	the actions associated with the dial, and compositors may use this
+	information to offer visual feedback about the button layout
+	(eg. on-screen displays).
+
+	The provided string 'description' is a UTF-8 encoded string to be
+	associated with this ring, and is considered user-visible; general
+	internationalization rules apply.
+
+	The serial argument will be that of the last
+	wp_tablet_pad_group.mode_switch event received for the group of this
+	dial. Requests providing other serials than the most recent one will be
+	ignored.
+      </description>
+      <arg name="description" type="string" summary="dial description"/>
+      <arg name="serial" type="uint" summary="serial of the mode switch event"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the dial object">
+	This destroys the client's resource for this dial object.
+      </description>
+    </request>
+
+    <event name="delta">
+      <description summary="delta movement">
+	Sent whenever the position on a dial changes.
+
+	This event carries the wheel delta as multiples or fractions
+	of 120 with each multiple of 120 representing one logical wheel detent.
+	For example, an axis_value120 of 30 is one quarter of
+	a logical wheel step in the positive direction, a value120 of
+	-240 are two logical wheel steps in the negative direction within the
+	same hardware event. See the wl_pointer.axis_value120 for more details.
+
+	The value120 must not be zero.
+      </description>
+      <arg name="value120" type="int" summary="rotation distance as fraction of 120"/>
+    </event>
+
+    <event name="frame">
+      <description summary="end of a dial event sequence">
+	Indicates the end of a set of events that represent one logical
+	hardware dial event. A client is expected to accumulate the data
+	in all events within the frame before proceeding.
+
+	All wp_tablet_pad_dial events before a wp_tablet_pad_dial.frame event belong
+	logically together.
+
+	A wp_tablet_pad_dial.frame event is sent for every logical event
+	group, even if the group only contains a single wp_tablet_pad_dial
+	event. Specifically, a client may get a sequence: delta, frame,
+	delta, frame, etc.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+    </event>
+  </interface>
+</protocol>

--- a/premake5.lua
+++ b/premake5.lua
@@ -66,6 +66,8 @@ project "GLFW"
 			"viewporter",
 			"wayland",
 			"xdg-activation-v1",
+			"cursor-shape-v1",
+			"tablet-v2",
 			"xdg-decoration-unstable-v1",
 			"xdg-shell"
 		}

--- a/premake5.lua
+++ b/premake5.lua
@@ -46,13 +46,43 @@ project "GLFW"
 			"src/glx_context.c",
 			"src/egl_context.c",
 			"src/osmesa_context.c",
-			"src/linux_joystick.c"
+			"src/linux_joystick.c",
+			"src/wl_init.c",
+			"src/wl_monitor.c",
+			"src/wl_window.c"
 		}
 
 		defines
 		{
-			"_GLFW_X11"
+			"_GLFW_X11",
+			"_GLFW_WAYLAND"
 		}
+
+		local protocols = {
+			"fractional-scale-v1",
+			"idle-inhibit-unstable-v1",
+			"pointer-constraints-unstable-v1",
+			"relative-pointer-unstable-v1",
+			"viewporter",
+			"wayland",
+			"xdg-activation-v1",
+			"xdg-decoration-unstable-v1",
+			"xdg-shell"
+		}
+
+		for _, protocol in ipairs(protocols) do
+			local out_file = "src/" .. protocol .. "-client-protocol.h"
+			local out_code_file = "src/" .. protocol .. "-client-protocol-code.h"
+
+			prebuildcommands {
+				"wayland-scanner client-header deps/wayland/" .. protocol .. ".xml " .. out_file,
+				"wayland-scanner private-code deps/wayland/" .. protocol .. ".xml " .. out_code_file
+			}
+
+			buildoutputs {
+				out_file
+			}
+		end
 
 	filter "system:macosx"
 		pic "On"

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -47,6 +47,8 @@
 #include "relative-pointer-unstable-v1-client-protocol.h"
 #include "pointer-constraints-unstable-v1-client-protocol.h"
 #include "fractional-scale-v1-client-protocol.h"
+#include "cursor-shape-v1-client-protocol.h"
+#include "tablet-v2-client-protocol.h"
 #include "xdg-activation-v1-client-protocol.h"
 #include "idle-inhibit-unstable-v1-client-protocol.h"
 
@@ -81,6 +83,14 @@
 
 #define types _glfw_fractional_scale_types
 #include "fractional-scale-v1-client-protocol-code.h"
+#undef types
+
+#define types _glfw_tablet_v2_types
+#include "tablet-v2-client-protocol-code.h"
+#undef types
+
+#define types _glfw_cursor_shape_types
+#include "cursor-shape-v1-client-protocol-code.h"
 #undef types
 
 #define types _glfw_xdg_activation_types
@@ -199,6 +209,13 @@ static void registryHandleGlobal(void* userData,
         _glfw.wl.fractionalScaleManager =
             wl_registry_bind(registry, name,
                              &wp_fractional_scale_manager_v1_interface,
+                             1);
+    }
+    else if (strcmp(interface, "wp_cursor_shape_manager_v1") == 0)
+    {
+        _glfw.wl.cursorShapeManager =
+            wl_registry_bind(registry, name,
+                             &wp_cursor_shape_manager_v1_interface,
                              1);
     }
 }
@@ -991,6 +1008,8 @@ void _glfwTerminateWayland(void)
         xdg_activation_v1_destroy(_glfw.wl.activationManager);
     if (_glfw.wl.fractionalScaleManager)
         wp_fractional_scale_manager_v1_destroy(_glfw.wl.fractionalScaleManager);
+    if (_glfw.wl.cursorShapeManager)
+        wp_cursor_shape_manager_v1_destroy(_glfw.wl.cursorShapeManager);
     if (_glfw.wl.registry)
         wl_registry_destroy(_glfw.wl.registry);
     if (_glfw.wl.display)

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -821,6 +821,11 @@ int _glfwInitWayland(void)
             _glfwPlatformGetModuleSymbol(_glfw.wl.libdecor.handle, "libdecor_frame_set_visibility");
         _glfw.wl.libdecor.libdecor_frame_get_xdg_toplevel_ = (PFN_libdecor_frame_get_xdg_toplevel)
             _glfwPlatformGetModuleSymbol(_glfw.wl.libdecor.handle, "libdecor_frame_get_xdg_toplevel");
+        // Optional: only present in libdecor 0.2+. Not in the required-set below
+        // (its absence doesn't prevent libdecor from working for toplevels), but
+        // when present it lets xdg_popup windows be parented to libdecor frames.
+        _glfw.wl.libdecor.libdecor_frame_get_xdg_surface_ = (PFN_libdecor_frame_get_xdg_surface)
+            _glfwPlatformGetModuleSymbol(_glfw.wl.libdecor.handle, "libdecor_frame_get_xdg_surface");
         _glfw.wl.libdecor.libdecor_configuration_get_content_size_ = (PFN_libdecor_configuration_get_content_size)
             _glfwPlatformGetModuleSymbol(_glfw.wl.libdecor.handle, "libdecor_configuration_get_content_size");
         _glfw.wl.libdecor.libdecor_configuration_get_window_state_ = (PFN_libdecor_configuration_get_window_state)

--- a/src/wl_monitor.c
+++ b/src/wl_monitor.c
@@ -207,10 +207,16 @@ void _glfwGetMonitorPosWayland(_GLFWmonitor* monitor, int* xpos, int* ypos)
 void _glfwGetMonitorContentScaleWayland(_GLFWmonitor* monitor,
                                         float* xscale, float* yscale)
 {
+    float scale;
+    if (monitor->wl.fractionalScaleNumerator)
+        scale = (float) monitor->wl.fractionalScaleNumerator / 120.f;
+    else
+        scale = (float) monitor->wl.scale;
+
     if (xscale)
-        *xscale = (float) monitor->wl.scale;
+        *xscale = scale;
     if (yscale)
-        *yscale = (float) monitor->wl.scale;
+        *yscale = scale;
 }
 
 void _glfwGetMonitorWorkareaWayland(_GLFWmonitor* monitor,

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -432,7 +432,6 @@ typedef struct _GLFWwindowWayland
         _GLFWfallbackEdgeWayland    top, left, right, bottom;
         double                      pointerX, pointerY;
         uint32_t                    buttonPressSerial;
-        const char*                 cursorName;
     } fallback;
 
     uint32_t                        resizeEdge;

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -459,6 +459,8 @@ typedef struct _GLFWlibraryWayland
     struct zwp_idle_inhibit_manager_v1*     idleInhibitManager;
     struct xdg_activation_v1*               activationManager;
     struct wp_fractional_scale_manager_v1*  fractionalScaleManager;
+    struct wp_cursor_shape_manager_v1*      cursorShapeManager;
+    struct wp_cursor_shape_device_v1*       cursorShapeDevice;
 
     _GLFWofferWayland*          offers;
     unsigned int                offerCount;
@@ -649,6 +651,7 @@ typedef struct _GLFWcursorWayland
     int                         width, height;
     int                         xhot, yhot;
     int                         currentImage;
+    uint32_t                    cursorShape; // WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_* (0 if custom image)
 } _GLFWcursorWayland;
 
 GLFWbool _glfwConnectWayland(int platformID, _GLFWplatform* platform);

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -434,6 +434,8 @@ typedef struct _GLFWwindowWayland
         uint32_t                    buttonPressSerial;
         const char*                 cursorName;
     } fallback;
+
+    uint32_t                        resizeEdge;
 } _GLFWwindowWayland;
 
 // Wayland-specific global data

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -639,6 +639,7 @@ typedef struct _GLFWmonitorWayland
     int                         x;
     int                         y;
     int32_t                     scale;
+    int32_t                     fractionalScaleNumerator; // wp_fractional_scale_v1 numerator (0 = unknown, scale = N/120)
 } _GLFWmonitorWayland;
 
 // Wayland-specific per-cursor data

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -312,6 +312,7 @@ typedef void (* PFN_libdecor_frame_set_capabilities)(struct libdecor_frame*,enum
 typedef void (* PFN_libdecor_frame_unset_capabilities)(struct libdecor_frame*,enum libdecor_capabilities);
 typedef void (* PFN_libdecor_frame_set_visibility)(struct libdecor_frame*,bool visible);
 typedef struct xdg_toplevel* (* PFN_libdecor_frame_get_xdg_toplevel)(struct libdecor_frame*);
+typedef struct xdg_surface* (* PFN_libdecor_frame_get_xdg_surface)(struct libdecor_frame*);
 typedef bool (* PFN_libdecor_configuration_get_content_size)(struct libdecor_configuration*,struct libdecor_frame*,int*,int*);
 typedef bool (* PFN_libdecor_configuration_get_window_state)(struct libdecor_configuration*,enum libdecor_window_state*);
 typedef struct libdecor_state* (* PFN_libdecor_state_new)(int,int);
@@ -337,6 +338,7 @@ typedef void (* PFN_libdecor_state_free)(struct libdecor_state*);
 #define libdecor_frame_unset_capabilities _glfw.wl.libdecor.libdecor_frame_unset_capabilities_
 #define libdecor_frame_set_visibility _glfw.wl.libdecor.libdecor_frame_set_visibility_
 #define libdecor_frame_get_xdg_toplevel _glfw.wl.libdecor.libdecor_frame_get_xdg_toplevel_
+#define libdecor_frame_get_xdg_surface _glfw.wl.libdecor.libdecor_frame_get_xdg_surface_
 #define libdecor_configuration_get_content_size _glfw.wl.libdecor.libdecor_configuration_get_content_size_
 #define libdecor_configuration_get_window_state _glfw.wl.libdecor.libdecor_configuration_get_window_state_
 #define libdecor_state_new _glfw.wl.libdecor.libdecor_state_new_
@@ -396,9 +398,23 @@ typedef struct _GLFWwindowWayland
     struct {
         struct xdg_surface*     surface;
         struct xdg_toplevel*    toplevel;
+        struct xdg_popup*       popup;
         struct zxdg_toplevel_decoration_v1* decoration;
         uint32_t                decorationMode;
     } xdg;
+
+    // Set via glfwSetWindowPos before shell objects exist. Used as the
+    // anchor-rect origin (relative to the parent toplevel) when this window
+    // is created as an xdg_popup.
+    int                         pendingPosX, pendingPosY;
+    GLFWbool                    pendingPosSet;
+
+    // Captured from wndconfig.focused at create time. ImGui's GLFW backend
+    // unconditionally calls glfwWindowHint(GLFW_FOCUSED, false) for viewports;
+    // app-created toplevels (splash, main editor) leave the default `true`.
+    // That gives us a reliable "this is an ImGui viewport" signal that doesn't
+    // depend on version-gated hints like GLFW_FOCUS_ON_SHOW.
+    GLFWbool                    createdUnfocused;
 
     struct {
         struct libdecor_frame*  frame;
@@ -621,6 +637,7 @@ typedef struct _GLFWlibraryWayland
         PFN_libdecor_frame_unset_capabilities libdecor_frame_unset_capabilities_;
         PFN_libdecor_frame_set_visibility libdecor_frame_set_visibility_;
         PFN_libdecor_frame_get_xdg_toplevel libdecor_frame_get_xdg_toplevel_;
+        PFN_libdecor_frame_get_xdg_surface libdecor_frame_get_xdg_surface_;
         PFN_libdecor_configuration_get_content_size libdecor_configuration_get_content_size_;
         PFN_libdecor_configuration_get_window_state libdecor_configuration_get_window_state_;
         PFN_libdecor_state_new libdecor_state_new_;

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -1683,7 +1683,8 @@ static void updateResizeEdge(_GLFWwindow* window)
 {
     uint32_t edge = XDG_TOPLEVEL_RESIZE_EDGE_NONE;
 
-    if (window->resizable && !window->decorated && !window->monitor)
+    if (window->resizable && !window->decorated && !window->monitor &&
+        !window->wl.maximized && !window->wl.fullscreen)
     {
         edge = detectResizeEdge(window,
                                 (int) window->wl.cursorPosX,
@@ -1732,7 +1733,8 @@ static void processPointerButton(int button, int action)
         GLFWbool handled = GLFW_FALSE;
 
         if (button == GLFW_MOUSE_BUTTON_LEFT && action == GLFW_PRESS &&
-            !window->decorated && !window->monitor)
+            !window->decorated && !window->monitor &&
+            !window->wl.maximized && !window->wl.fullscreen)
         {
             struct xdg_toplevel* toplevel = window->wl.xdg.toplevel;
             if (window->wl.libdecor.frame)

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -284,6 +284,43 @@ static void destroyFallbackDecorations(_GLFWwindow* window)
     destroyFallbackEdge(&window->wl.fallback.bottom);
 }
 
+static void setNamedCursor(_GLFWwindow* window, const char* cursorName)
+{
+    struct wl_surface* surface = _glfw.wl.cursorSurface;
+    struct wl_cursor_theme* theme = _glfw.wl.cursorTheme;
+    int scale = 1;
+
+    if (window->wl.bufferScale > 1 && _glfw.wl.cursorThemeHiDPI)
+    {
+        // We only support up to scale=2 for now, since libwayland-cursor
+        // requires us to load a different theme for each size.
+        scale = 2;
+        theme = _glfw.wl.cursorThemeHiDPI;
+    }
+
+    struct wl_cursor* cursor = wl_cursor_theme_get_cursor(theme, cursorName);
+    if (!cursor)
+        return;
+
+    // TODO: handle animated cursors too.
+    struct wl_cursor_image* image = cursor->images[0];
+    if (!image)
+        return;
+
+    struct wl_buffer* buffer = wl_cursor_image_get_buffer(image);
+    if (!buffer)
+        return;
+
+    wl_pointer_set_cursor(_glfw.wl.pointer, _glfw.wl.pointerEnterSerial,
+                          surface,
+                          image->hotspot_x / scale,
+                          image->hotspot_y / scale);
+    wl_surface_set_buffer_scale(surface, scale);
+    wl_surface_attach(surface, buffer, 0, 0);
+    wl_surface_damage(surface, 0, 0, image->width, image->height);
+    wl_surface_commit(surface);
+}
+
 static void updateFallbackDecorationCursor(_GLFWwindow* window, double xpos, double ypos)
 {
     window->wl.fallback.pointerX = xpos;
@@ -325,40 +362,7 @@ static void updateFallbackDecorationCursor(_GLFWwindow* window, double xpos, dou
 
     if (window->wl.fallback.cursorName != cursorName)
     {
-        struct wl_surface* surface = _glfw.wl.cursorSurface;
-        struct wl_cursor_theme* theme = _glfw.wl.cursorTheme;
-        int scale = 1;
-
-        if (window->wl.bufferScale > 1 && _glfw.wl.cursorThemeHiDPI)
-        {
-            // We only support up to scale=2 for now, since libwayland-cursor
-            // requires us to load a different theme for each size.
-            scale = 2;
-            theme = _glfw.wl.cursorThemeHiDPI;
-        }
-
-        struct wl_cursor* cursor = wl_cursor_theme_get_cursor(theme, cursorName);
-        if (!cursor)
-            return;
-
-        // TODO: handle animated cursors too.
-        struct wl_cursor_image* image = cursor->images[0];
-        if (!image)
-            return;
-
-        struct wl_buffer* buffer = wl_cursor_image_get_buffer(image);
-        if (!buffer)
-            return;
-
-        wl_pointer_set_cursor(_glfw.wl.pointer, _glfw.wl.pointerEnterSerial,
-                              surface,
-                              image->hotspot_x / scale,
-                              image->hotspot_y / scale);
-        wl_surface_set_buffer_scale(surface, scale);
-        wl_surface_attach(surface, buffer, 0, 0);
-        wl_surface_damage(surface, 0, 0, image->width, image->height);
-        wl_surface_commit(surface);
-
+        setNamedCursor(window, cursorName);
         window->wl.fallback.cursorName = cursorName;
     }
 }
@@ -1538,12 +1542,72 @@ static void processPointerLeaveSurface(struct wl_surface* surface)
 
     _GLFWwindow* window = wl_surface_get_user_data(surface);
     if (window->wl.surface == surface)
+    {
+        window->wl.resizeEdge = XDG_TOPLEVEL_RESIZE_EDGE_NONE;
         _glfwInputCursorEnter(window, GLFW_FALSE);
+    }
     else
     {
         if (window->wl.fallback.decorations)
             window->wl.fallback.cursorName = NULL;
     }
+}
+
+static uint32_t detectResizeEdge(_GLFWwindow* window, int x, int y)
+{
+    const int w = window->wl.width;
+    const int h = window->wl.height;
+    const int border = 8;
+
+    const GLFWbool onLeft   = (x < border);
+    const GLFWbool onRight  = (x >= w - border);
+    const GLFWbool onTop    = (y < border);
+    const GLFWbool onBottom = (y >= h - border);
+
+    if      (onTop    && onLeft)  return XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT;
+    else if (onTop    && onRight) return XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT;
+    else if (onBottom && onLeft)  return XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT;
+    else if (onBottom && onRight) return XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT;
+    else if (onTop)               return XDG_TOPLEVEL_RESIZE_EDGE_TOP;
+    else if (onBottom)            return XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM;
+    else if (onLeft)              return XDG_TOPLEVEL_RESIZE_EDGE_LEFT;
+    else if (onRight)             return XDG_TOPLEVEL_RESIZE_EDGE_RIGHT;
+
+    return XDG_TOPLEVEL_RESIZE_EDGE_NONE;
+}
+
+static const char* resizeEdgeCursorName(uint32_t edge)
+{
+    switch (edge)
+    {
+        case XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT:     return "nw-resize";
+        case XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT:    return "ne-resize";
+        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT:  return "sw-resize";
+        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT: return "se-resize";
+        case XDG_TOPLEVEL_RESIZE_EDGE_TOP:          return "n-resize";
+        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM:       return "s-resize";
+        case XDG_TOPLEVEL_RESIZE_EDGE_LEFT:         return "w-resize";
+        case XDG_TOPLEVEL_RESIZE_EDGE_RIGHT:        return "e-resize";
+        default:                                    return NULL;
+    }
+}
+
+static void updateResizeEdge(_GLFWwindow* window)
+{
+    uint32_t edge = XDG_TOPLEVEL_RESIZE_EDGE_NONE;
+
+    if (window->resizable && !window->decorated && !window->monitor)
+    {
+        edge = detectResizeEdge(window,
+                                (int) window->wl.cursorPosX,
+                                (int) window->wl.cursorPosY);
+    }
+
+    if (edge == window->wl.resizeEdge)
+        return;
+
+    window->wl.resizeEdge = edge;
+    _glfwSetCursorWayland(window, window->cursor);
 }
 
 static void processPointerMotion(double xpos, double ypos)
@@ -1556,6 +1620,7 @@ static void processPointerMotion(double xpos, double ypos)
             window->wl.cursorPosX = xpos;
             window->wl.cursorPosY = ypos;
             _glfwInputCursorPos(window, window->wl.cursorPosX, window->wl.cursorPosY);
+            updateResizeEdge(window);
         }
     }
     else
@@ -1570,28 +1635,47 @@ static void processPointerButton(int button, int action)
     _GLFWwindow* window = wl_surface_get_user_data(_glfw.wl.pointerSurface);
     if (window->wl.surface == _glfw.wl.pointerSurface)
     {
-        // For undecorated windows, check titlebar hit test on left-click
-        // to initiate compositor-driven window drag (mirrors the X11 path)
-        if (button == GLFW_MOUSE_BUTTON_LEFT && action == GLFW_PRESS && !window->decorated)
+        // For undecorated windows, provide OS-level resize borders
+        // and titlebar drag via xdg_toplevel — matching the X11
+        // _NET_WM_MOVERESIZE behaviour
+        GLFWbool handled = GLFW_FALSE;
+
+        if (button == GLFW_MOUSE_BUTTON_LEFT && action == GLFW_PRESS &&
+            !window->decorated && !window->monitor)
         {
-            int titlebarHit = 0;
-            _glfwInputTitleBarHitTest(window, (int) window->wl.cursorPosX, (int) window->wl.cursorPosY, &titlebarHit);
+            struct xdg_toplevel* toplevel = window->wl.xdg.toplevel;
+            if (window->wl.libdecor.frame)
+                toplevel = libdecor_frame_get_xdg_toplevel(window->wl.libdecor.frame);
 
-            if (titlebarHit)
+            if (toplevel)
             {
-                struct xdg_toplevel* toplevel = window->wl.xdg.toplevel;
-                if (window->wl.libdecor.frame)
-                    toplevel = libdecor_frame_get_xdg_toplevel(window->wl.libdecor.frame);
+                const int x = (int) window->wl.cursorPosX;
+                const int y = (int) window->wl.cursorPosY;
+                uint32_t edges = window->resizable
+                    ? detectResizeEdge(window, x, y)
+                    : XDG_TOPLEVEL_RESIZE_EDGE_NONE;
 
-                if (toplevel)
+                if (edges != XDG_TOPLEVEL_RESIZE_EDGE_NONE)
                 {
-                    xdg_toplevel_move(toplevel, _glfw.wl.seat, _glfw.wl.serial);
-                    return;
+                    xdg_toplevel_resize(toplevel, _glfw.wl.seat,
+                                        _glfw.wl.serial, edges);
+                    handled = GLFW_TRUE;
+                }
+                else
+                {
+                    int titlebarHit = 0;
+                    _glfwInputTitleBarHitTest(window, x, y, &titlebarHit);
+                    if (titlebarHit)
+                    {
+                        xdg_toplevel_move(toplevel, _glfw.wl.seat, _glfw.wl.serial);
+                        handled = GLFW_TRUE;
+                    }
                 }
             }
         }
 
-        _glfwInputMouseClick(window, button, action, _glfw.wl.xkb.modifiers);
+        if (!handled)
+            _glfwInputMouseClick(window, button, action, _glfw.wl.xkb.modifiers);
     }
     else
     {
@@ -3340,7 +3424,12 @@ void _glfwSetCursorWayland(_GLFWwindow* window, _GLFWcursor* cursor)
     if (window->cursorMode == GLFW_CURSOR_NORMAL ||
         window->cursorMode == GLFW_CURSOR_CAPTURED)
     {
-        if (cursor)
+        // Resize edge cursor takes priority over the application cursor
+        if (window->wl.resizeEdge != XDG_TOPLEVEL_RESIZE_EDGE_NONE)
+        {
+            setNamedCursor(window, resizeEdgeCursorName(window->wl.resizeEdge));
+        }
+        else if (cursor)
             setCursorImage(window, &cursor->wl);
         else
         {

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -51,6 +51,7 @@
 #include "xdg-activation-v1-client-protocol.h"
 #include "idle-inhibit-unstable-v1-client-protocol.h"
 #include "fractional-scale-v1-client-protocol.h"
+#include "cursor-shape-v1-client-protocol.h"
 
 #define GLFW_BORDER_SIZE    4
 #define GLFW_CAPTION_HEIGHT 24
@@ -60,6 +61,73 @@
 #define GLFW_PENDING_MOTION     4
 #define GLFW_PENDING_SCROLL     8
 #define GLFW_PENDING_DISCRETE   16
+
+// Unified cursor descriptor table.  Each row maps a GLFW standard cursor
+// shape and/or an xdg_toplevel resize edge to the wp_cursor_shape protocol
+// enum, plus XDG and X11 fallback cursor name strings for compositors that
+// don't support wp_cursor_shape_v1.
+//
+// Rows with resizeEdge == NONE are the canonical entries for a GLFW shape
+// (used by _glfwCreateStandardCursorWayland).  Rows with a specific edge
+// are used by applyCursor for directional resize cursors.
+//
+typedef struct {
+    int                 glfwShape;  // GLFW_*_CURSOR
+    uint32_t            resizeEdge; // XDG_TOPLEVEL_RESIZE_EDGE_* (NONE if N/A)
+    uint32_t            shape;      // WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_*
+    const char*         name;       // XDG cursor name
+    const char*         fallback;   // X11 core cursor name
+} _GLFWcursorDesc;
+
+static const _GLFWcursorDesc cursorTable[] =
+{
+    // Non-resize cursors
+    { GLFW_ARROW_CURSOR,         XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_DEFAULT,     "default",       "left_ptr"            },
+    { GLFW_IBEAM_CURSOR,         XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_TEXT,        "text",          "xterm"              },
+    { GLFW_CROSSHAIR_CURSOR,     XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_CROSSHAIR,   "crosshair",     "crosshair"          },
+    { GLFW_POINTING_HAND_CURSOR, XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_POINTER,     "pointer",       "hand2"              },
+    { GLFW_RESIZE_ALL_CURSOR,    XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_ALL_SCROLL,  "all-scroll",    "fleur"              },
+    { GLFW_NOT_ALLOWED_CURSOR,   XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_NOT_ALLOWED, "not-allowed",   "not-allowed"        },
+
+    // Bidirectional resize cursors (canonical GLFW entries, no specific edge)
+    { GLFW_RESIZE_EW_CURSOR,     XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_EW_RESIZE,   "ew-resize",     "sb_h_double_arrow"  },
+    { GLFW_RESIZE_NS_CURSOR,     XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_NS_RESIZE,   "ns-resize",     "sb_v_double_arrow"  },
+    { GLFW_RESIZE_NWSE_CURSOR,   XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_NWSE_RESIZE, "nwse-resize",   "nwse-resize"        },
+    { GLFW_RESIZE_NESW_CURSOR,   XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_NESW_RESIZE, "nesw-resize",   "nesw-resize"        },
+
+    // Directional resize cursors (per-edge)
+    { GLFW_RESIZE_NS_CURSOR,     XDG_TOPLEVEL_RESIZE_EDGE_TOP,         WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_N_RESIZE,    "n-resize",      "top_side"           },
+    { GLFW_RESIZE_NS_CURSOR,     XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM,      WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_S_RESIZE,    "s-resize",      "bottom_side"        },
+    { GLFW_RESIZE_EW_CURSOR,     XDG_TOPLEVEL_RESIZE_EDGE_LEFT,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_W_RESIZE,    "w-resize",      "left_side"          },
+    { GLFW_RESIZE_EW_CURSOR,     XDG_TOPLEVEL_RESIZE_EDGE_RIGHT,       WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_E_RESIZE,    "e-resize",      "right_side"         },
+    { GLFW_RESIZE_NWSE_CURSOR,   XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT,    WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_NW_RESIZE,   "nw-resize",     "top_left_corner"    },
+    { GLFW_RESIZE_NWSE_CURSOR,   XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT,WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_SE_RESIZE,   "se-resize",     "bottom_right_corner"},
+    { GLFW_RESIZE_NESW_CURSOR,   XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT,   WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_NE_RESIZE,   "ne-resize",     "top_right_corner"   },
+    { GLFW_RESIZE_NESW_CURSOR,   XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT, WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_SW_RESIZE,   "sw-resize",     "bottom_left_corner" },
+};
+
+// Finds the canonical entry for a GLFW standard cursor shape (edge == NONE).
+static const _GLFWcursorDesc* findCursorDescByShape(int glfwShape)
+{
+    for (size_t i = 0; i < sizeof(cursorTable) / sizeof(cursorTable[0]); i++)
+    {
+        if (cursorTable[i].glfwShape == glfwShape &&
+            cursorTable[i].resizeEdge == XDG_TOPLEVEL_RESIZE_EDGE_NONE)
+            return &cursorTable[i];
+    }
+    return NULL;
+}
+
+// Finds the directional entry for a specific resize edge.
+static const _GLFWcursorDesc* findCursorDescByEdge(uint32_t edge)
+{
+    for (size_t i = 0; i < sizeof(cursorTable) / sizeof(cursorTable[0]); i++)
+    {
+        if (cursorTable[i].resizeEdge == edge)
+            return &cursorTable[i];
+    }
+    return NULL;
+}
 
 static int createTmpfileCloexec(char* tmpname)
 {
@@ -334,41 +402,16 @@ static _GLFWcursorWayland lookupNamedCursor(const char* name, const char* fallba
     _GLFWcursorWayland cw = { NULL, NULL, NULL, 0, 0, 0, 0, 0 };
 
     cw.cursor = wl_cursor_theme_get_cursor(_glfw.wl.cursorTheme, name);
-    if (!cw.cursor && fallback)
+    if (!cw.cursor)
         cw.cursor = wl_cursor_theme_get_cursor(_glfw.wl.cursorTheme, fallback);
 
     if (_glfw.wl.cursorThemeHiDPI)
     {
         cw.cursorHiDPI = wl_cursor_theme_get_cursor(_glfw.wl.cursorThemeHiDPI, name);
-        if (!cw.cursorHiDPI && fallback)
+        if (!cw.cursorHiDPI)
             cw.cursorHiDPI = wl_cursor_theme_get_cursor(_glfw.wl.cursorThemeHiDPI, fallback);
     }
 
-    return cw;
-}
-
-static _GLFWcursorWayland lookupResizeEdgeCursor(uint32_t edge)
-{
-    const char* name = NULL;
-    const char* fallback = NULL;
-
-    switch (edge)
-    {
-        case XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT:     name = "nw-resize"; fallback = "top_left_corner";     break;
-        case XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT:    name = "ne-resize"; fallback = "top_right_corner";    break;
-        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT:  name = "sw-resize"; fallback = "bottom_left_corner";  break;
-        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT: name = "se-resize"; fallback = "bottom_right_corner"; break;
-        case XDG_TOPLEVEL_RESIZE_EDGE_TOP:          name = "n-resize";  fallback = "top_side";            break;
-        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM:       name = "s-resize";  fallback = "bottom_side";         break;
-        case XDG_TOPLEVEL_RESIZE_EDGE_LEFT:         name = "w-resize";  fallback = "left_side";           break;
-        case XDG_TOPLEVEL_RESIZE_EDGE_RIGHT:        name = "e-resize";  fallback = "right_side";          break;
-        default: break;
-    }
-
-    if (name)
-        return lookupNamedCursor(name, fallback);
-
-    _GLFWcursorWayland cw = { NULL, NULL, NULL, 0, 0, 0, 0, 0 };
     return cw;
 }
 
@@ -429,6 +472,25 @@ static uint32_t detectResizeEdge(_GLFWwindow* window, int x, int y)
     return XDG_TOPLEVEL_RESIZE_EDGE_NONE;
 }
 
+// Sets the cursor from a descriptor, preferring wp_cursor_shape_v1 when
+// available and falling back to wl_cursor_theme lookup.
+static void setDescCursor(_GLFWwindow* window, const _GLFWcursorDesc* desc)
+{
+    if (_glfw.wl.cursorShapeDevice)
+    {
+        wp_cursor_shape_device_v1_set_shape(
+            _glfw.wl.cursorShapeDevice,
+            _glfw.wl.pointerEnterSerial,
+            desc->shape);
+    }
+    else
+    {
+        _GLFWcursorWayland cw = lookupNamedCursor(desc->name, desc->fallback);
+        if (cw.cursor)
+            setCursorImage(window, &cw);
+    }
+}
+
 /* Anything that wants to change the cursor shape should call this. */
 static void applyCursor(_GLFWwindow* window)
 {
@@ -439,59 +501,66 @@ static void applyCursor(_GLFWwindow* window)
 
         if (pointerWindow == window)
         {
+            // Determine the resize edge (if any) for both main and
+            // fallback decoration surfaces
+            uint32_t edge = XDG_TOPLEVEL_RESIZE_EDGE_NONE;
+
             if (window->wl.surface == _glfw.wl.pointerSurface)
             {
-                // Main surface
-                if (window->cursorMode == GLFW_CURSOR_HIDDEN ||
-                    window->cursorMode == GLFW_CURSOR_DISABLED)
-                {
-                    wl_pointer_set_cursor(_glfw.wl.pointer,
-                                          _glfw.wl.pointerEnterSerial,
-                                          NULL, 0, 0);
-                }
-                else if (window->wl.resizeEdge != XDG_TOPLEVEL_RESIZE_EDGE_NONE)
-                {
-                    _GLFWcursorWayland cw = lookupResizeEdgeCursor(window->wl.resizeEdge);
-                    if (cw.cursor)
-                        setCursorImage(window, &cw);
-                }
-                else if (window->cursor)
-                {
-                    setCursorImage(window, &window->cursor->wl);
-                }
-                else
-                {
-                    _GLFWcursorWayland cw = lookupNamedCursor("left_ptr", NULL);
-                    if (cw.cursor)
-                        setCursorImage(window, &cw);
-                    else
-                        _glfwInputError(GLFW_PLATFORM_ERROR,
-                                        "Wayland: Standard cursor not found");
-                }
+                edge = window->wl.resizeEdge;
             }
-            else if (window->wl.fallback.decorations)
+            else if (window->wl.fallback.decorations && window->resizable)
             {
-                // Fallback decoration surface
-                // coordinates and reuse the same edge detection
                 int wx, wy;
-                uint32_t edge = XDG_TOPLEVEL_RESIZE_EDGE_NONE;
-                if (window->resizable &&
-                    fallbackToWindowCoords(window,
+                if (fallbackToWindowCoords(window,
                                            window->wl.fallback.pointerX,
                                            window->wl.fallback.pointerY,
                                            &wx, &wy))
                 {
                     edge = detectResizeEdge(window, wx, wy);
                 }
+            }
 
-                _GLFWcursorWayland cw;
-                if (edge != XDG_TOPLEVEL_RESIZE_EDGE_NONE)
-                    cw = lookupResizeEdgeCursor(edge);
+            // Hidden/disabled cursor
+            if (window->wl.surface == _glfw.wl.pointerSurface &&
+                (window->cursorMode == GLFW_CURSOR_HIDDEN ||
+                 window->cursorMode == GLFW_CURSOR_DISABLED))
+            {
+                wl_pointer_set_cursor(_glfw.wl.pointer,
+                                      _glfw.wl.pointerEnterSerial,
+                                      NULL, 0, 0);
+            }
+            // Resize edge cursor
+            else if (edge != XDG_TOPLEVEL_RESIZE_EDGE_NONE)
+            {
+                const _GLFWcursorDesc* desc = findCursorDescByEdge(edge);
+                if (desc)
+                    setDescCursor(window, desc);
+            }
+            // Application cursor (main surface only)
+            else if (window->wl.surface == _glfw.wl.pointerSurface &&
+                     window->cursor)
+            {
+                if (_glfw.wl.cursorShapeDevice &&
+                    window->cursor->wl.cursorShape)
+                {
+                    wp_cursor_shape_device_v1_set_shape(
+                        _glfw.wl.cursorShapeDevice,
+                        _glfw.wl.pointerEnterSerial,
+                        window->cursor->wl.cursorShape);
+                }
                 else
-                    cw = lookupNamedCursor("left_ptr", NULL);
-
-                if (cw.cursor)
-                    setCursorImage(window, &cw);
+                    setCursorImage(window, &window->cursor->wl);
+            }
+            // Default cursor
+            else
+            {
+                const _GLFWcursorDesc* desc = findCursorDescByShape(GLFW_ARROW_CURSOR);
+                if (desc)
+                    setDescCursor(window, desc);
+                else
+                    _glfwInputError(GLFW_PLATFORM_ERROR,
+                                    "Wayland: Standard cursor not found");
             }
         }
     }
@@ -2185,9 +2254,22 @@ static void seatHandleCapabilities(void* userData,
     {
         _glfw.wl.pointer = wl_seat_get_pointer(seat);
         wl_pointer_add_listener(_glfw.wl.pointer, &pointerListener, NULL);
+
+        if (_glfw.wl.cursorShapeManager)
+        {
+            _glfw.wl.cursorShapeDevice =
+                wp_cursor_shape_manager_v1_get_pointer(
+                    _glfw.wl.cursorShapeManager, _glfw.wl.pointer);
+        }
     }
     else if (!(caps & WL_SEAT_CAPABILITY_POINTER) && _glfw.wl.pointer)
     {
+        if (_glfw.wl.cursorShapeDevice)
+        {
+            wp_cursor_shape_device_v1_destroy(_glfw.wl.cursorShapeDevice);
+            _glfw.wl.cursorShapeDevice = NULL;
+        }
+
         if (wl_pointer_get_version(_glfw.wl.pointer) >= WL_POINTER_RELEASE_SINCE_VERSION)
             wl_pointer_release(_glfw.wl.pointer);
         else
@@ -3164,102 +3246,26 @@ GLFWbool _glfwCreateCursorWayland(_GLFWcursor* cursor,
 
 GLFWbool _glfwCreateStandardCursorWayland(_GLFWcursor* cursor, int shape)
 {
-    const char* name = NULL;
-
-    // Try the XDG names first
-    switch (shape)
+    const _GLFWcursorDesc* desc = findCursorDescByShape(shape);
+    if (!desc)
     {
-        case GLFW_ARROW_CURSOR:
-            name = "default";
-            break;
-        case GLFW_IBEAM_CURSOR:
-            name = "text";
-            break;
-        case GLFW_CROSSHAIR_CURSOR:
-            name = "crosshair";
-            break;
-        case GLFW_POINTING_HAND_CURSOR:
-            name = "pointer";
-            break;
-        case GLFW_RESIZE_EW_CURSOR:
-            name = "ew-resize";
-            break;
-        case GLFW_RESIZE_NS_CURSOR:
-            name = "ns-resize";
-            break;
-        case GLFW_RESIZE_NWSE_CURSOR:
-            name = "nwse-resize";
-            break;
-        case GLFW_RESIZE_NESW_CURSOR:
-            name = "nesw-resize";
-            break;
-        case GLFW_RESIZE_ALL_CURSOR:
-            name = "all-scroll";
-            break;
-        case GLFW_NOT_ALLOWED_CURSOR:
-            name = "not-allowed";
-            break;
+        _glfwInputError(GLFW_CURSOR_UNAVAILABLE,
+                        "Wayland: Standard cursor shape unavailable");
+        return GLFW_FALSE;
     }
 
-    cursor->wl.cursor = wl_cursor_theme_get_cursor(_glfw.wl.cursorTheme, name);
-
-    if (_glfw.wl.cursorThemeHiDPI)
+    _GLFWcursorWayland cw = lookupNamedCursor(desc->name, desc->fallback);
+    if (!cw.cursor)
     {
-        cursor->wl.cursorHiDPI =
-            wl_cursor_theme_get_cursor(_glfw.wl.cursorThemeHiDPI, name);
+        _glfwInputError(GLFW_CURSOR_UNAVAILABLE,
+                        "Wayland: Failed to create standard cursor \"%s\"",
+                        desc->name);
+        return GLFW_FALSE;
     }
 
-    if (!cursor->wl.cursor)
-    {
-        // Fall back to the core X11 names
-        switch (shape)
-        {
-            case GLFW_ARROW_CURSOR:
-                name = "left_ptr";
-                break;
-            case GLFW_IBEAM_CURSOR:
-                name = "xterm";
-                break;
-            case GLFW_CROSSHAIR_CURSOR:
-                name = "crosshair";
-                break;
-            case GLFW_POINTING_HAND_CURSOR:
-                name = "hand2";
-                break;
-            case GLFW_RESIZE_EW_CURSOR:
-                name = "sb_h_double_arrow";
-                break;
-            case GLFW_RESIZE_NS_CURSOR:
-                name = "sb_v_double_arrow";
-                break;
-            case GLFW_RESIZE_ALL_CURSOR:
-                name = "fleur";
-                break;
-            default:
-                _glfwInputError(GLFW_CURSOR_UNAVAILABLE,
-                                "Wayland: Standard cursor shape unavailable");
-                return GLFW_FALSE;
-        }
-
-        cursor->wl.cursor = wl_cursor_theme_get_cursor(_glfw.wl.cursorTheme, name);
-        if (!cursor->wl.cursor)
-        {
-            _glfwInputError(GLFW_CURSOR_UNAVAILABLE,
-                            "Wayland: Failed to create standard cursor \"%s\"",
-                            name);
-            return GLFW_FALSE;
-        }
-
-        if (_glfw.wl.cursorThemeHiDPI)
-        {
-            if (!cursor->wl.cursorHiDPI)
-            {
-                cursor->wl.cursorHiDPI =
-                    wl_cursor_theme_get_cursor(_glfw.wl.cursorThemeHiDPI, name);
-            }
-        }
-    }
-
+    cursor->wl.cursor = cw.cursor;
+    cursor->wl.cursorHiDPI = cw.cursorHiDPI;
+    cursor->wl.cursorShape = desc->shape;
     return GLFW_TRUE;
 }
 

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -738,8 +738,11 @@ void _glfwUpdateBufferScaleFromOutputsWayland(_GLFWwindow* window)
     {
         window->wl.bufferScale = maxScale;
         wl_surface_set_buffer_scale(window->wl.surface, maxScale);
-        _glfwInputWindowContentScale(window, maxScale, maxScale);
         resizeFramebuffer(window);
+
+        float xscale, yscale;
+        _glfwGetWindowContentScaleWayland(window, &xscale, &yscale);
+        _glfwInputWindowContentScale(window, xscale, yscale);
 
         if (window->wl.visible)
             _glfwInputWindowDamage(window);
@@ -867,8 +870,11 @@ void fractionalScaleHandlePreferredScale(void* userData,
     _GLFWwindow* window = userData;
 
     window->wl.scalingNumerator = numerator;
-    _glfwInputWindowContentScale(window, numerator / 120.f, numerator / 120.f);
     resizeFramebuffer(window);
+
+    float xscale, yscale;
+    _glfwGetWindowContentScaleWayland(window, &xscale, &yscale);
+    _glfwInputWindowContentScale(window, xscale, yscale);
 
     // Update all monitors with the fractional scale so glfwGetMonitorContentScale
     // returns the accurate value instead of the integer wl_output scale.

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -870,6 +870,11 @@ void fractionalScaleHandlePreferredScale(void* userData,
     _glfwInputWindowContentScale(window, numerator / 120.f, numerator / 120.f);
     resizeFramebuffer(window);
 
+    // Update all monitors with the fractional scale so glfwGetMonitorContentScale
+    // returns the accurate value instead of the integer wl_output scale.
+    for (int i = 0; i < _glfw.monitorCount; i++)
+        _glfw.monitors[i]->wl.fractionalScaleNumerator = numerator;
+
     if (window->wl.visible)
         _glfwInputWindowDamage(window);
 }

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -284,88 +284,219 @@ static void destroyFallbackDecorations(_GLFWwindow* window)
     destroyFallbackEdge(&window->wl.fallback.bottom);
 }
 
-static void setNamedCursor(_GLFWwindow* window, const char* cursorName)
+static void setCursorImage(_GLFWwindow* window, _GLFWcursorWayland* cursorWayland)
 {
+    struct itimerspec timer = {0};
+    struct wl_cursor* wlCursor = cursorWayland->cursor;
+    struct wl_cursor_image* image;
+    struct wl_buffer* buffer;
     struct wl_surface* surface = _glfw.wl.cursorSurface;
-    struct wl_cursor_theme* theme = _glfw.wl.cursorTheme;
     int scale = 1;
 
-    if (window->wl.bufferScale > 1 && _glfw.wl.cursorThemeHiDPI)
+    if (!wlCursor)
+        buffer = cursorWayland->buffer;
+    else
     {
-        // We only support up to scale=2 for now, since libwayland-cursor
-        // requires us to load a different theme for each size.
-        scale = 2;
-        theme = _glfw.wl.cursorThemeHiDPI;
+        if (window->wl.bufferScale > 1 && cursorWayland->cursorHiDPI)
+        {
+            wlCursor = cursorWayland->cursorHiDPI;
+            scale = 2;
+        }
+
+        image = wlCursor->images[cursorWayland->currentImage];
+        buffer = wl_cursor_image_get_buffer(image);
+        if (!buffer)
+            return;
+
+        timer.it_value.tv_sec = image->delay / 1000;
+        timer.it_value.tv_nsec = (image->delay % 1000) * 1000000;
+        timerfd_settime(_glfw.wl.cursorTimerfd, 0, &timer, NULL);
+
+        cursorWayland->width = image->width;
+        cursorWayland->height = image->height;
+        cursorWayland->xhot = image->hotspot_x;
+        cursorWayland->yhot = image->hotspot_y;
     }
-
-    struct wl_cursor* cursor = wl_cursor_theme_get_cursor(theme, cursorName);
-    if (!cursor)
-        return;
-
-    // TODO: handle animated cursors too.
-    struct wl_cursor_image* image = cursor->images[0];
-    if (!image)
-        return;
-
-    struct wl_buffer* buffer = wl_cursor_image_get_buffer(image);
-    if (!buffer)
-        return;
 
     wl_pointer_set_cursor(_glfw.wl.pointer, _glfw.wl.pointerEnterSerial,
                           surface,
-                          image->hotspot_x / scale,
-                          image->hotspot_y / scale);
+                          cursorWayland->xhot / scale,
+                          cursorWayland->yhot / scale);
     wl_surface_set_buffer_scale(surface, scale);
     wl_surface_attach(surface, buffer, 0, 0);
-    wl_surface_damage(surface, 0, 0, image->width, image->height);
+    wl_surface_damage(surface, 0, 0,
+                      cursorWayland->width, cursorWayland->height);
     wl_surface_commit(surface);
 }
 
-static void updateFallbackDecorationCursor(_GLFWwindow* window, double xpos, double ypos)
+static _GLFWcursorWayland lookupNamedCursor(const char* name, const char* fallback)
 {
-    window->wl.fallback.pointerX = xpos;
-    window->wl.fallback.pointerY = ypos;
+    _GLFWcursorWayland cw = { NULL, NULL, NULL, 0, 0, 0, 0, 0 };
 
-    const char* cursorName = "left_ptr";
+    cw.cursor = wl_cursor_theme_get_cursor(_glfw.wl.cursorTheme, name);
+    if (!cw.cursor && fallback)
+        cw.cursor = wl_cursor_theme_get_cursor(_glfw.wl.cursorTheme, fallback);
 
-    if (window->resizable)
+    if (_glfw.wl.cursorThemeHiDPI)
     {
-        if (_glfw.wl.pointerSurface == window->wl.fallback.top.surface)
-        {
-            if (ypos < GLFW_BORDER_SIZE)
-                cursorName = "n-resize";
-        }
-        else if (_glfw.wl.pointerSurface == window->wl.fallback.left.surface)
-        {
-            if (ypos < GLFW_BORDER_SIZE)
-                cursorName = "nw-resize";
-            else
-                cursorName = "w-resize";
-        }
-        else if (_glfw.wl.pointerSurface == window->wl.fallback.right.surface)
-        {
-            if (ypos < GLFW_BORDER_SIZE)
-                cursorName = "ne-resize";
-            else
-                cursorName = "e-resize";
-        }
-        else if (_glfw.wl.pointerSurface == window->wl.fallback.bottom.surface)
-        {
-            if (xpos < GLFW_BORDER_SIZE)
-                cursorName = "sw-resize";
-            else if (xpos > window->wl.width + GLFW_BORDER_SIZE)
-                cursorName = "se-resize";
-            else
-                cursorName = "s-resize";
-        }
+        cw.cursorHiDPI = wl_cursor_theme_get_cursor(_glfw.wl.cursorThemeHiDPI, name);
+        if (!cw.cursorHiDPI && fallback)
+            cw.cursorHiDPI = wl_cursor_theme_get_cursor(_glfw.wl.cursorThemeHiDPI, fallback);
     }
 
-    if (window->wl.fallback.cursorName != cursorName)
+    return cw;
+}
+
+static _GLFWcursorWayland lookupResizeEdgeCursor(uint32_t edge)
+{
+    const char* name = NULL;
+    const char* fallback = NULL;
+
+    switch (edge)
     {
-        setNamedCursor(window, cursorName);
-        window->wl.fallback.cursorName = cursorName;
+        case XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT:     name = "nw-resize"; fallback = "top_left_corner";     break;
+        case XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT:    name = "ne-resize"; fallback = "top_right_corner";    break;
+        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT:  name = "sw-resize"; fallback = "bottom_left_corner";  break;
+        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT: name = "se-resize"; fallback = "bottom_right_corner"; break;
+        case XDG_TOPLEVEL_RESIZE_EDGE_TOP:          name = "n-resize";  fallback = "top_side";            break;
+        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM:       name = "s-resize";  fallback = "bottom_side";         break;
+        case XDG_TOPLEVEL_RESIZE_EDGE_LEFT:         name = "w-resize";  fallback = "left_side";           break;
+        case XDG_TOPLEVEL_RESIZE_EDGE_RIGHT:        name = "e-resize";  fallback = "right_side";          break;
+        default: break;
+    }
+
+    if (name)
+        return lookupNamedCursor(name, fallback);
+
+    _GLFWcursorWayland cw = { NULL, NULL, NULL, 0, 0, 0, 0, 0 };
+    return cw;
+}
+
+// Translates fallback decoration subsurface-local coordinates to
+// main window coordinates so detectResizeEdge can handle both paths.
+static GLFWbool fallbackToWindowCoords(_GLFWwindow* window,
+                                       double sx, double sy,
+                                       int* wx, int* wy)
+{
+    if (_glfw.wl.pointerSurface == window->wl.fallback.top.surface)
+    {
+        *wx = (int) sx;
+        *wy = (int) sy - GLFW_CAPTION_HEIGHT;
+    }
+    else if (_glfw.wl.pointerSurface == window->wl.fallback.left.surface)
+    {
+        *wx = (int) sx - GLFW_BORDER_SIZE;
+        *wy = (int) sy - GLFW_CAPTION_HEIGHT;
+    }
+    else if (_glfw.wl.pointerSurface == window->wl.fallback.right.surface)
+    {
+        *wx = (int) sx + window->wl.width;
+        *wy = (int) sy - GLFW_CAPTION_HEIGHT;
+    }
+    else if (_glfw.wl.pointerSurface == window->wl.fallback.bottom.surface)
+    {
+        *wx = (int) sx - GLFW_BORDER_SIZE;
+        *wy = (int) sy + window->wl.height;
+    }
+    else
+        return GLFW_FALSE;
+
+    return GLFW_TRUE;
+}
+
+static uint32_t detectResizeEdge(_GLFWwindow* window, int x, int y)
+{
+    const int w = window->wl.width;
+    const int h = window->wl.height;
+    // Note that this is not the same as GLFW_BORDER_SIZE, because undecorated windows need a bigger
+    // hit zone than decorated ones, where a resize can be started from slightly outside the window.
+    const int border = 8;
+
+    const GLFWbool onLeft   = (x < border);
+    const GLFWbool onRight  = (x >= w - border);
+    const GLFWbool onTop    = (y < border);
+    const GLFWbool onBottom = (y >= h - border);
+
+    if      (onTop    && onLeft)  return XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT;
+    else if (onTop    && onRight) return XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT;
+    else if (onBottom && onLeft)  return XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT;
+    else if (onBottom && onRight) return XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT;
+    else if (onTop)               return XDG_TOPLEVEL_RESIZE_EDGE_TOP;
+    else if (onBottom)            return XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM;
+    else if (onLeft)              return XDG_TOPLEVEL_RESIZE_EDGE_LEFT;
+    else if (onRight)             return XDG_TOPLEVEL_RESIZE_EDGE_RIGHT;
+
+    return XDG_TOPLEVEL_RESIZE_EDGE_NONE;
+}
+
+/* Anything that wants to change the cursor shape should call this. */
+static void applyCursor(_GLFWwindow* window)
+{
+    if (_glfw.wl.pointer && _glfw.wl.pointerSurface)
+    {
+        _GLFWwindow* pointerWindow =
+            wl_surface_get_user_data(_glfw.wl.pointerSurface);
+
+        if (pointerWindow == window)
+        {
+            if (window->wl.surface == _glfw.wl.pointerSurface)
+            {
+                // Main surface
+                if (window->cursorMode == GLFW_CURSOR_HIDDEN ||
+                    window->cursorMode == GLFW_CURSOR_DISABLED)
+                {
+                    wl_pointer_set_cursor(_glfw.wl.pointer,
+                                          _glfw.wl.pointerEnterSerial,
+                                          NULL, 0, 0);
+                }
+                else if (window->wl.resizeEdge != XDG_TOPLEVEL_RESIZE_EDGE_NONE)
+                {
+                    _GLFWcursorWayland cw = lookupResizeEdgeCursor(window->wl.resizeEdge);
+                    if (cw.cursor)
+                        setCursorImage(window, &cw);
+                }
+                else if (window->cursor)
+                {
+                    setCursorImage(window, &window->cursor->wl);
+                }
+                else
+                {
+                    _GLFWcursorWayland cw = lookupNamedCursor("left_ptr", NULL);
+                    if (cw.cursor)
+                        setCursorImage(window, &cw);
+                    else
+                        _glfwInputError(GLFW_PLATFORM_ERROR,
+                                        "Wayland: Standard cursor not found");
+                }
+            }
+            else if (window->wl.fallback.decorations)
+            {
+                // Fallback decoration surface
+                // coordinates and reuse the same edge detection
+                int wx, wy;
+                uint32_t edge = XDG_TOPLEVEL_RESIZE_EDGE_NONE;
+                if (window->resizable &&
+                    fallbackToWindowCoords(window,
+                                           window->wl.fallback.pointerX,
+                                           window->wl.fallback.pointerY,
+                                           &wx, &wy))
+                {
+                    edge = detectResizeEdge(window, wx, wy);
+                }
+
+                _GLFWcursorWayland cw;
+                if (edge != XDG_TOPLEVEL_RESIZE_EDGE_NONE)
+                    cw = lookupResizeEdgeCursor(edge);
+                else
+                    cw = lookupNamedCursor("left_ptr", NULL);
+
+                if (cw.cursor)
+                    setCursorImage(window, &cw);
+            }
+        }
     }
 }
+
 
 static void handleFallbackDecorationButton(_GLFWwindow* window, int button, int action)
 {
@@ -378,41 +509,18 @@ static void handleFallbackDecorationButton(_GLFWwindow* window, int button, int 
 
     if (button == GLFW_MOUSE_BUTTON_LEFT)
     {
+        int wx, wy;
         uint32_t edges = XDG_TOPLEVEL_RESIZE_EDGE_NONE;
-
-        if (_glfw.wl.pointerSurface == window->wl.fallback.top.surface)
+        if (window->resizable &&
+            fallbackToWindowCoords(window, xpos, ypos, &wx, &wy))
         {
-            if (ypos < GLFW_BORDER_SIZE)
-                edges = XDG_TOPLEVEL_RESIZE_EDGE_TOP;
-            else
-                xdg_toplevel_move(window->wl.xdg.toplevel, _glfw.wl.seat, serial);
-        }
-        else if (_glfw.wl.pointerSurface == window->wl.fallback.left.surface)
-        {
-            if (ypos < GLFW_BORDER_SIZE)
-                edges = XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT;
-            else
-                edges = XDG_TOPLEVEL_RESIZE_EDGE_LEFT;
-        }
-        else if (_glfw.wl.pointerSurface == window->wl.fallback.right.surface)
-        {
-            if (ypos < GLFW_BORDER_SIZE)
-                edges = XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT;
-            else
-                edges = XDG_TOPLEVEL_RESIZE_EDGE_RIGHT;
-        }
-        else if (_glfw.wl.pointerSurface == window->wl.fallback.bottom.surface)
-        {
-            if (xpos < GLFW_BORDER_SIZE)
-                edges = XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT;
-            else if (xpos > window->wl.width + GLFW_BORDER_SIZE)
-                edges = XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT;
-            else
-                edges = XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM;
+            edges = detectResizeEdge(window, wx, wy);
         }
 
         if (edges != XDG_TOPLEVEL_RESIZE_EDGE_NONE)
             xdg_toplevel_resize(window->wl.xdg.toplevel, _glfw.wl.seat, serial, edges);
+        else if (_glfw.wl.pointerSurface == window->wl.fallback.top.surface)
+            xdg_toplevel_move(window->wl.xdg.toplevel, _glfw.wl.seat, serial);
     }
     else if (button == GLFW_MOUSE_BUTTON_RIGHT)
     {
@@ -1230,67 +1338,21 @@ static GLFWbool createNativeSurface(_GLFWwindow* window,
     return GLFW_TRUE;
 }
 
-static void setCursorImage(_GLFWwindow* window,
-                           _GLFWcursorWayland* cursorWayland)
-{
-    struct itimerspec timer = {0};
-    struct wl_cursor* wlCursor = cursorWayland->cursor;
-    struct wl_cursor_image* image;
-    struct wl_buffer* buffer;
-    struct wl_surface* surface = _glfw.wl.cursorSurface;
-    int scale = 1;
-
-    if (!wlCursor)
-        buffer = cursorWayland->buffer;
-    else
-    {
-        if (window->wl.bufferScale > 1 && cursorWayland->cursorHiDPI)
-        {
-            wlCursor = cursorWayland->cursorHiDPI;
-            scale = 2;
-        }
-
-        image = wlCursor->images[cursorWayland->currentImage];
-        buffer = wl_cursor_image_get_buffer(image);
-        if (!buffer)
-            return;
-
-        timer.it_value.tv_sec = image->delay / 1000;
-        timer.it_value.tv_nsec = (image->delay % 1000) * 1000000;
-        timerfd_settime(_glfw.wl.cursorTimerfd, 0, &timer, NULL);
-
-        cursorWayland->width = image->width;
-        cursorWayland->height = image->height;
-        cursorWayland->xhot = image->hotspot_x;
-        cursorWayland->yhot = image->hotspot_y;
-    }
-
-    wl_pointer_set_cursor(_glfw.wl.pointer, _glfw.wl.pointerEnterSerial,
-                          surface,
-                          cursorWayland->xhot / scale,
-                          cursorWayland->yhot / scale);
-    wl_surface_set_buffer_scale(surface, scale);
-    wl_surface_attach(surface, buffer, 0, 0);
-    wl_surface_damage(surface, 0, 0,
-                      cursorWayland->width, cursorWayland->height);
-    wl_surface_commit(surface);
-}
-
 static void incrementCursorImage(void)
 {
-    if (!_glfw.wl.pointerSurface)
-        return;
-
-    _GLFWwindow* window = wl_surface_get_user_data(_glfw.wl.pointerSurface);
-    if (window->wl.surface != _glfw.wl.pointerSurface)
-        return;
-
-    _GLFWcursor* cursor = window->cursor;
-    if (cursor && cursor->wl.cursor)
+    if (_glfw.wl.pointerSurface)
     {
-        cursor->wl.currentImage += 1;
-        cursor->wl.currentImage %= cursor->wl.cursor->image_count;
-        setCursorImage(window, &cursor->wl);
+        _GLFWwindow* window = wl_surface_get_user_data(_glfw.wl.pointerSurface);
+        if (window->wl.surface == _glfw.wl.pointerSurface)
+        {
+            _GLFWcursor* cursor = window->cursor;
+            if (cursor && cursor->wl.cursor)
+            {
+                cursor->wl.currentImage += 1;
+                cursor->wl.currentImage %= cursor->wl.cursor->image_count;
+                applyCursor(window);
+            }
+        }
     }
 }
 
@@ -1546,50 +1608,6 @@ static void processPointerLeaveSurface(struct wl_surface* surface)
         window->wl.resizeEdge = XDG_TOPLEVEL_RESIZE_EDGE_NONE;
         _glfwInputCursorEnter(window, GLFW_FALSE);
     }
-    else
-    {
-        if (window->wl.fallback.decorations)
-            window->wl.fallback.cursorName = NULL;
-    }
-}
-
-static uint32_t detectResizeEdge(_GLFWwindow* window, int x, int y)
-{
-    const int w = window->wl.width;
-    const int h = window->wl.height;
-    const int border = 8;
-
-    const GLFWbool onLeft   = (x < border);
-    const GLFWbool onRight  = (x >= w - border);
-    const GLFWbool onTop    = (y < border);
-    const GLFWbool onBottom = (y >= h - border);
-
-    if      (onTop    && onLeft)  return XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT;
-    else if (onTop    && onRight) return XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT;
-    else if (onBottom && onLeft)  return XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT;
-    else if (onBottom && onRight) return XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT;
-    else if (onTop)               return XDG_TOPLEVEL_RESIZE_EDGE_TOP;
-    else if (onBottom)            return XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM;
-    else if (onLeft)              return XDG_TOPLEVEL_RESIZE_EDGE_LEFT;
-    else if (onRight)             return XDG_TOPLEVEL_RESIZE_EDGE_RIGHT;
-
-    return XDG_TOPLEVEL_RESIZE_EDGE_NONE;
-}
-
-static const char* resizeEdgeCursorName(uint32_t edge)
-{
-    switch (edge)
-    {
-        case XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT:     return "nw-resize";
-        case XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT:    return "ne-resize";
-        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT:  return "sw-resize";
-        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT: return "se-resize";
-        case XDG_TOPLEVEL_RESIZE_EDGE_TOP:          return "n-resize";
-        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM:       return "s-resize";
-        case XDG_TOPLEVEL_RESIZE_EDGE_LEFT:         return "w-resize";
-        case XDG_TOPLEVEL_RESIZE_EDGE_RIGHT:        return "e-resize";
-        default:                                    return NULL;
-    }
 }
 
 static void updateResizeEdge(_GLFWwindow* window)
@@ -1603,11 +1621,11 @@ static void updateResizeEdge(_GLFWwindow* window)
                                 (int) window->wl.cursorPosY);
     }
 
-    if (edge == window->wl.resizeEdge)
-        return;
-
-    window->wl.resizeEdge = edge;
-    _glfwSetCursorWayland(window, window->cursor);
+    if (edge != window->wl.resizeEdge)
+    {
+        window->wl.resizeEdge = edge;
+        applyCursor(window);
+    }
 }
 
 static void processPointerMotion(double xpos, double ypos)
@@ -1626,7 +1644,11 @@ static void processPointerMotion(double xpos, double ypos)
     else
     {
         if (window->wl.fallback.decorations)
-            updateFallbackDecorationCursor(window, xpos, ypos);
+        {
+            window->wl.fallback.pointerX = xpos;
+            window->wl.fallback.pointerY = ypos;
+            applyCursor(window);
+        }
     }
 }
 
@@ -3421,52 +3443,7 @@ void _glfwSetCursorWayland(_GLFWwindow* window, _GLFWcursor* cursor)
             unconfinePointer(window);
     }
 
-    if (window->cursorMode == GLFW_CURSOR_NORMAL ||
-        window->cursorMode == GLFW_CURSOR_CAPTURED)
-    {
-        // Resize edge cursor takes priority over the application cursor
-        if (window->wl.resizeEdge != XDG_TOPLEVEL_RESIZE_EDGE_NONE)
-        {
-            setNamedCursor(window, resizeEdgeCursorName(window->wl.resizeEdge));
-        }
-        else if (cursor)
-            setCursorImage(window, &cursor->wl);
-        else
-        {
-            struct wl_cursor* defaultCursor =
-                wl_cursor_theme_get_cursor(_glfw.wl.cursorTheme, "left_ptr");
-            if (!defaultCursor)
-            {
-                _glfwInputError(GLFW_PLATFORM_ERROR,
-                                "Wayland: Standard cursor not found");
-                return;
-            }
-
-            struct wl_cursor* defaultCursorHiDPI = NULL;
-            if (_glfw.wl.cursorThemeHiDPI)
-            {
-                defaultCursorHiDPI =
-                    wl_cursor_theme_get_cursor(_glfw.wl.cursorThemeHiDPI, "left_ptr");
-            }
-
-            _GLFWcursorWayland cursorWayland =
-            {
-                defaultCursor,
-                defaultCursorHiDPI,
-                NULL,
-                0, 0,
-                0, 0,
-                0
-            };
-
-            setCursorImage(window, &cursorWayland);
-        }
-    }
-    else if (window->cursorMode == GLFW_CURSOR_HIDDEN ||
-             window->cursorMode == GLFW_CURSOR_DISABLED)
-    {
-        wl_pointer_set_cursor(_glfw.wl.pointer, _glfw.wl.pointerEnterSerial, NULL, 0, 0);
-    }
+    applyCursor(window);
 }
 
 static void dataSourceHandleTarget(void* userData,

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -3257,7 +3257,7 @@ GLFWbool _glfwCreateStandardCursorWayland(_GLFWcursor* cursor, int shape)
     }
 
     _GLFWcursorWayland cw = lookupNamedCursor(desc->name, desc->fallback);
-    if (!cw.cursor)
+    if (!cw.cursor && !_glfw.wl.cursorShapeManager)
     {
         _glfwInputError(GLFW_CURSOR_UNAVAILABLE,
                         "Wayland: Failed to create standard cursor \"%s\"",

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -62,27 +62,19 @@
 #define GLFW_PENDING_SCROLL     8
 #define GLFW_PENDING_DISCRETE   16
 
-// Unified cursor descriptor table.  Each row maps a GLFW standard cursor
-// shape and/or an xdg_toplevel resize edge to the wp_cursor_shape protocol
-// enum, plus XDG and X11 fallback cursor name strings for compositors that
-// don't support wp_cursor_shape_v1.
-//
-// Rows with resizeEdge == NONE are the canonical entries for a GLFW shape
-// (used by _glfwCreateStandardCursorWayland).  Rows with a specific edge
-// are used by applyCursor for directional resize cursors.
-//
 typedef struct {
     int                 glfwShape;  // GLFW_*_CURSOR
-    uint32_t            resizeEdge; // XDG_TOPLEVEL_RESIZE_EDGE_* (NONE if N/A)
+    uint32_t            resizeEdge; // XDG_TOPLEVEL_RESIZE_EDGE_* (NONE for non-resizing-related shapes)
     uint32_t            shape;      // WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_*
     const char*         name;       // XDG cursor name
     const char*         fallback;   // X11 core cursor name
 } _GLFWcursorDesc;
 
+// This table relates various mouse-cursor-shape-related constants to each other so if you already
+// have one you can find an equivalent value for a different library/context.
 static const _GLFWcursorDesc cursorTable[] =
 {
-    // Non-resize cursors
-    { GLFW_ARROW_CURSOR,         XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_DEFAULT,     "default",       "left_ptr"            },
+    { GLFW_ARROW_CURSOR,         XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_DEFAULT,     "default",       "left_ptr"           },
     { GLFW_IBEAM_CURSOR,         XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_TEXT,        "text",          "xterm"              },
     { GLFW_CROSSHAIR_CURSOR,     XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_CROSSHAIR,   "crosshair",     "crosshair"          },
     { GLFW_POINTING_HAND_CURSOR, XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_POINTER,     "pointer",       "hand2"              },
@@ -1733,8 +1725,7 @@ static void processPointerButton(int button, int action)
         GLFWbool handled = GLFW_FALSE;
 
         if (button == GLFW_MOUSE_BUTTON_LEFT && action == GLFW_PRESS &&
-            !window->decorated && !window->monitor &&
-            !window->wl.maximized && !window->wl.fullscreen)
+            !window->decorated && !window->monitor)
         {
             struct xdg_toplevel* toplevel = window->wl.xdg.toplevel;
             if (window->wl.libdecor.frame)
@@ -1744,9 +1735,14 @@ static void processPointerButton(int button, int action)
             {
                 const int x = (int) window->wl.cursorPosX;
                 const int y = (int) window->wl.cursorPosY;
-                uint32_t edges = window->resizable
-                    ? detectResizeEdge(window, x, y)
-                    : XDG_TOPLEVEL_RESIZE_EDGE_NONE;
+
+                // Resize edges are only active when not maximized/fullscreen
+                uint32_t edges = XDG_TOPLEVEL_RESIZE_EDGE_NONE;
+                if (window->resizable &&
+                    !window->wl.maximized && !window->wl.fullscreen)
+                {
+                    edges = detectResizeEdge(window, x, y);
+                }
 
                 if (edges != XDG_TOPLEVEL_RESIZE_EDGE_NONE)
                 {

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -1569,7 +1569,30 @@ static void processPointerButton(int button, int action)
 {
     _GLFWwindow* window = wl_surface_get_user_data(_glfw.wl.pointerSurface);
     if (window->wl.surface == _glfw.wl.pointerSurface)
+    {
+        // For undecorated windows, check titlebar hit test on left-click
+        // to initiate compositor-driven window drag (mirrors the X11 path)
+        if (button == GLFW_MOUSE_BUTTON_LEFT && action == GLFW_PRESS && !window->decorated)
+        {
+            int titlebarHit = 0;
+            _glfwInputTitleBarHitTest(window, (int) window->wl.cursorPosX, (int) window->wl.cursorPosY, &titlebarHit);
+
+            if (titlebarHit)
+            {
+                struct xdg_toplevel* toplevel = window->wl.xdg.toplevel;
+                if (window->wl.libdecor.frame)
+                    toplevel = libdecor_frame_get_xdg_toplevel(window->wl.libdecor.frame);
+
+                if (toplevel)
+                {
+                    xdg_toplevel_move(toplevel, _glfw.wl.seat, _glfw.wl.serial);
+                    return;
+                }
+            }
+        }
+
         _glfwInputMouseClick(window, button, action, _glfw.wl.xkb.modifiers);
+    }
     else
     {
         if (window->wl.fallback.decorations)

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -1247,6 +1247,155 @@ static void updateXdgSizeLimits(_GLFWwindow* window)
     xdg_toplevel_set_max_size(window->wl.xdg.toplevel, maxwidth, maxheight);
 }
 
+static void xdgPopupSurfaceHandleConfigure(void* userData,
+                                           struct xdg_surface* surface,
+                                           uint32_t serial)
+{
+    // Popups don't go through the toplevel state machine, so just ACK the
+    // configure and mark the window as visible. Size is already known from
+    // the positioner we handed to the compositor at creation.
+    _GLFWwindow* window = userData;
+    xdg_surface_ack_configure(surface, serial);
+
+    if (!window->wl.visible)
+    {
+        window->wl.visible = GLFW_TRUE;
+        _glfwInputWindowDamage(window);
+    }
+}
+
+static const struct xdg_surface_listener xdgPopupSurfaceListener =
+{
+    xdgPopupSurfaceHandleConfigure
+};
+
+static void xdgPopupHandleConfigure(void* userData,
+                                    struct xdg_popup* popup,
+                                    int32_t x, int32_t y,
+                                    int32_t width, int32_t height)
+{
+    // Compositor-confirmed popup geometry. ImGui already has its own layout,
+    // so nothing to propagate here beyond the surface-level size sync.
+    _GLFWwindow* window = userData;
+    if (width > 0 && height > 0 &&
+        (width != window->wl.width || height != window->wl.height))
+    {
+        window->wl.width = width;
+        window->wl.height = height;
+        resizeFramebuffer(window);
+        _glfwInputWindowSize(window, width, height);
+    }
+}
+
+static void xdgPopupHandlePopupDone(void* userData, struct xdg_popup* popup)
+{
+    // Compositor dismissed the popup (e.g. user clicked outside). Ask the
+    // owning application to close the window; ImGui will tear down the viewport.
+    _GLFWwindow* window = userData;
+    _glfwInputWindowCloseRequest(window);
+}
+
+static void xdgPopupHandleRepositioned(void* userData,
+                                       struct xdg_popup* popup,
+                                       uint32_t token)
+{
+    // Unused: we don't currently issue xdg_popup.reposition requests.
+}
+
+static const struct xdg_popup_listener xdgPopupListener =
+{
+    xdgPopupHandleConfigure,
+    xdgPopupHandlePopupDone,
+    xdgPopupHandleRepositioned,
+};
+
+// Resolve the xdg_surface of a window that owns a mapped toplevel, whether
+// created directly via xdg-shell or wrapped by libdecor. Returns NULL if the
+// window has no queryable xdg_surface (libdecor < 0.2 lacks the accessor).
+static struct xdg_surface* getWindowXdgSurface(_GLFWwindow* w)
+{
+    if (w->wl.xdg.surface)
+        return w->wl.xdg.surface;
+    if (w->wl.libdecor.frame && _glfw.wl.libdecor.libdecor_frame_get_xdg_surface_)
+        return libdecor_frame_get_xdg_surface(w->wl.libdecor.frame);
+    return NULL;
+}
+
+// Walk the GLFW window list and return the first window that owns a mapped
+// xdg_toplevel (directly or through libdecor) and has a queryable xdg_surface.
+// That window acts as the parent surface for any popup we spawn.
+static _GLFWwindow* findWaylandPopupParent(_GLFWwindow* self)
+{
+    for (_GLFWwindow* w = _glfw.windowListHead; w; w = w->next)
+    {
+        if (w == self) continue;
+        if (w->wl.xdg.popup) continue;
+        if (!getWindowXdgSurface(w)) continue;
+        if (w->wl.xdg.toplevel || w->wl.libdecor.frame)
+            return w;
+    }
+    return NULL;
+}
+
+static GLFWbool createXdgPopupShellObjects(_GLFWwindow* window,
+                                           _GLFWwindow* parent)
+{
+    window->wl.xdg.surface = xdg_wm_base_get_xdg_surface(_glfw.wl.wmBase,
+                                                         window->wl.surface);
+    if (!window->wl.xdg.surface)
+    {
+        _glfwInputError(GLFW_PLATFORM_ERROR,
+                        "Wayland: Failed to create xdg-surface for popup");
+        return GLFW_FALSE;
+    }
+    xdg_surface_add_listener(window->wl.xdg.surface, &xdgPopupSurfaceListener, window);
+
+    struct xdg_positioner* positioner =
+        xdg_wm_base_create_positioner(_glfw.wl.wmBase);
+    if (!positioner)
+    {
+        _glfwInputError(GLFW_PLATFORM_ERROR,
+                        "Wayland: Failed to create xdg-positioner for popup");
+        return GLFW_FALSE;
+    }
+
+    const int w = window->wl.width  > 0 ? window->wl.width  : 1;
+    const int h = window->wl.height > 0 ? window->wl.height : 1;
+    xdg_positioner_set_size(positioner, w, h);
+
+    // Treat the coords handed to glfwSetWindowPos as parent-relative, because
+    // on Wayland there is no global coordinate space. ImGui's main viewport
+    // lives at (0, 0) in its own space, so menus/tooltips positioned against
+    // it already carry correct parent-relative offsets.
+    const int px = window->wl.pendingPosSet ? window->wl.pendingPosX : 0;
+    const int py = window->wl.pendingPosSet ? window->wl.pendingPosY : 0;
+    xdg_positioner_set_anchor_rect(positioner, px, py, 1, 1);
+    xdg_positioner_set_anchor(positioner, XDG_POSITIONER_ANCHOR_TOP_LEFT);
+    xdg_positioner_set_gravity(positioner, XDG_POSITIONER_GRAVITY_BOTTOM_RIGHT);
+    xdg_positioner_set_constraint_adjustment(positioner,
+        XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_SLIDE_X |
+        XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_SLIDE_Y |
+        XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_X |
+        XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_Y);
+
+    window->wl.xdg.popup = xdg_surface_get_popup(window->wl.xdg.surface,
+                                                 getWindowXdgSurface(parent),
+                                                 positioner);
+    xdg_positioner_destroy(positioner);
+
+    if (!window->wl.xdg.popup)
+    {
+        _glfwInputError(GLFW_PLATFORM_ERROR,
+                        "Wayland: Failed to create xdg-popup");
+        return GLFW_FALSE;
+    }
+    xdg_popup_add_listener(window->wl.xdg.popup, &xdgPopupListener, window);
+
+    wl_surface_commit(window->wl.surface);
+    wl_display_roundtrip(_glfw.wl.display);
+    return GLFW_TRUE;
+}
+
 static GLFWbool createXdgShellObjects(_GLFWwindow* window)
 {
     window->wl.xdg.surface = xdg_wm_base_get_xdg_surface(_glfw.wl.wmBase,
@@ -1321,6 +1470,19 @@ static GLFWbool createXdgShellObjects(_GLFWwindow* window)
 
 static GLFWbool createShellObjects(_GLFWwindow* window)
 {
+    // Treat ImGui-style transient viewports as xdg_popups so they appear
+    // relative to the main window on Wayland (toplevel positioning is
+    // protocol-forbidden). The signal is `createdUnfocused` — ImGui's GLFW
+    // backend unconditionally sets GLFW_FOCUSED=false for viewport windows,
+    // whereas app-created toplevels (splash, main editor) leave the default
+    // `true`, so they stay as real toplevels.
+    if (window->wl.createdUnfocused && !window->decorated && !window->monitor)
+    {
+        _GLFWwindow* parent = findWaylandPopupParent(window);
+        if (parent)
+            return createXdgPopupShellObjects(window, parent);
+    }
+
     if (_glfw.wl.libdecor.context)
     {
         if (createLibdecorFrame(window))
@@ -1340,6 +1502,9 @@ static void destroyShellObjects(_GLFWwindow* window)
     if (window->wl.xdg.decoration)
         zxdg_toplevel_decoration_v1_destroy(window->wl.xdg.decoration);
 
+    if (window->wl.xdg.popup)
+        xdg_popup_destroy(window->wl.xdg.popup);
+
     if (window->wl.xdg.toplevel)
         xdg_toplevel_destroy(window->wl.xdg.toplevel);
 
@@ -1349,6 +1514,7 @@ static void destroyShellObjects(_GLFWwindow* window)
     window->wl.libdecor.frame = NULL;
     window->wl.xdg.decoration = NULL;
     window->wl.xdg.decorationMode = 0;
+    window->wl.xdg.popup = NULL;
     window->wl.xdg.toplevel = NULL;
     window->wl.xdg.surface = NULL;
 }
@@ -2581,6 +2747,8 @@ GLFWbool _glfwCreateWindowWayland(_GLFWwindow* window,
                                   const _GLFWctxconfig* ctxconfig,
                                   const _GLFWfbconfig* fbconfig)
 {
+    window->wl.createdUnfocused = !wndconfig->focused;
+
     if (!createNativeSurface(window, wndconfig, fbconfig))
         return GLFW_FALSE;
 
@@ -2727,19 +2895,31 @@ void _glfwSetWindowIconWayland(_GLFWwindow* window,
 
 void _glfwGetWindowPosWayland(_GLFWwindow* window, int* xpos, int* ypos)
 {
-    // A Wayland client is not aware of its position, so just warn and leave it
-    // as (0, 0)
-
-    _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
-                    "Wayland: The platform does not provide the window position");
+    // A Wayland client is not aware of its global position. For popup windows
+    // we do know the requested parent-relative anchor we were created at, so
+    // report that; for toplevels, there's no meaningful value to return.
+    //
+    // Stay silent: ImGui's viewport code polls this every frame and the
+    // warning would flood the log.
+    if (window->wl.pendingPosSet)
+    {
+        if (xpos) *xpos = window->wl.pendingPosX;
+        if (ypos) *ypos = window->wl.pendingPosY;
+    }
 }
 
 void _glfwSetWindowPosWayland(_GLFWwindow* window, int xpos, int ypos)
 {
-    // A Wayland client can not set its position, so just warn
+    if (!window->wl.xdg.surface && !window->wl.libdecor.frame)
+    {
+        window->wl.pendingPosX = xpos;
+        window->wl.pendingPosY = ypos;
+        window->wl.pendingPosSet = GLFW_TRUE;
+        return;
+    }
 
     _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
-                    "Wayland: The platform does not support setting the window position");
+                    "Wayland: The platform does not support setting the window position after it has been mapped");
 }
 
 void _glfwGetWindowSizeWayland(_GLFWwindow* window, int* width, int* height)
@@ -2916,7 +3096,7 @@ void _glfwMaximizeWindowWayland(_GLFWwindow* window)
 
 void _glfwShowWindowWayland(_GLFWwindow* window)
 {
-    if (!window->wl.libdecor.frame && !window->wl.xdg.toplevel)
+    if (!window->wl.libdecor.frame && !window->wl.xdg.toplevel && !window->wl.xdg.popup)
     {
         // NOTE: The XDG surface and role are created here so command-line applications
         //       with off-screen windows do not appear in for example the Unity dock


### PR DESCRIPTION
I changed a lot of the Wayland backend to fix a lot of problems:
- DPI is now calculated correctly, with fractional scaling
- Undecorated windows are draggable via the title bar
- Undecorated windows are resizable via their edges
- Resizing edges are disabled for maximised windows
- The mouse cursor appears as a resize cursor while hovering the edge of the window
- There is only one function that decides what shape the cursor should be, avoiding glitchiness
- Native cursor shapes are preferred