### PR TITLE
Wayland support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,5 @@ tests/windows
 # Hazel-specific
 bin
 bin-int
+src/*-client-protocol.h
+src/*-client-protocol-code.h

--- a/deps/wayland/cursor-shape-v1.xml
+++ b/deps/wayland/cursor-shape-v1.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="cursor_shape_v1">
+  <copyright>
+    Copyright 2018 The Chromium Authors
+    Copyright 2023 Simon Ser
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="wp_cursor_shape_manager_v1" version="2">
+    <description summary="cursor shape manager">
+      This global offers an alternative, optional way to set cursor images. This
+      new way uses enumerated cursors instead of a wl_surface like
+      wl_pointer.set_cursor does.
+
+      Warning! The protocol described in this file is currently in the testing
+      phase. Backward compatible changes may be added together with the
+      corresponding interface version bump. Backward incompatible changes can
+      only be done by creating a new major version of the extension.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        Destroy the cursor shape manager.
+      </description>
+    </request>
+
+    <request name="get_pointer">
+      <description summary="manage the cursor shape of a pointer device">
+        Obtain a wp_cursor_shape_device_v1 for a wl_pointer object.
+
+        When the pointer capability is removed from the wl_seat, the
+        wp_cursor_shape_device_v1 object becomes inert.
+      </description>
+      <arg name="cursor_shape_device" type="new_id" interface="wp_cursor_shape_device_v1"/>
+      <arg name="pointer" type="object" interface="wl_pointer"/>
+    </request>
+
+    <request name="get_tablet_tool_v2">
+      <description summary="manage the cursor shape of a tablet tool device">
+        Obtain a wp_cursor_shape_device_v1 for a zwp_tablet_tool_v2 object.
+
+        When the zwp_tablet_tool_v2 is removed, the wp_cursor_shape_device_v1
+        object becomes inert.
+      </description>
+      <arg name="cursor_shape_device" type="new_id" interface="wp_cursor_shape_device_v1"/>
+      <arg name="tablet_tool" type="object" interface="zwp_tablet_tool_v2"/>
+    </request>
+  </interface>
+
+  <interface name="wp_cursor_shape_device_v1" version="2">
+    <description summary="cursor shape for a device">
+      This interface allows clients to set the cursor shape.
+    </description>
+
+    <enum name="shape">
+      <description summary="cursor shapes">
+        This enum describes cursor shapes.
+
+        The names are taken from the CSS W3C specification:
+        https://w3c.github.io/csswg-drafts/css-ui/#cursor
+        with a few additions.
+
+        Note that there are some groups of cursor shapes that are related:
+        The first group is drag-and-drop cursors which are used to indicate
+        the selected action during dnd operations. The second group is resize
+        cursors which are used to indicate resizing and moving possibilities
+        on window borders. It is recommended that the shapes in these groups
+        should use visually compatible images and metaphors.
+      </description>
+      <entry name="default" value="1" summary="default cursor"/>
+      <entry name="context_menu" value="2" summary="a context menu is available for the object under the cursor"/>
+      <entry name="help" value="3" summary="help is available for the object under the cursor"/>
+      <entry name="pointer" value="4" summary="pointer that indicates a link or another interactive element"/>
+      <entry name="progress" value="5" summary="progress indicator"/>
+      <entry name="wait" value="6" summary="program is busy, user should wait"/>
+      <entry name="cell" value="7" summary="a cell or set of cells may be selected"/>
+      <entry name="crosshair" value="8" summary="simple crosshair"/>
+      <entry name="text" value="9" summary="text may be selected"/>
+      <entry name="vertical_text" value="10" summary="vertical text may be selected"/>
+      <entry name="alias" value="11" summary="drag-and-drop: alias of/shortcut to something is to be created"/>
+      <entry name="copy" value="12" summary="drag-and-drop: something is to be copied"/>
+      <entry name="move" value="13" summary="drag-and-drop: something is to be moved"/>
+      <entry name="no_drop" value="14" summary="drag-and-drop: the dragged item cannot be dropped at the current cursor location"/>
+      <entry name="not_allowed" value="15" summary="drag-and-drop: the requested action will not be carried out"/>
+      <entry name="grab" value="16" summary="drag-and-drop: something can be grabbed"/>
+      <entry name="grabbing" value="17" summary="drag-and-drop: something is being grabbed"/>
+      <entry name="e_resize" value="18" summary="resizing: the east border is to be moved"/>
+      <entry name="n_resize" value="19" summary="resizing: the north border is to be moved"/>
+      <entry name="ne_resize" value="20" summary="resizing: the north-east corner is to be moved"/>
+      <entry name="nw_resize" value="21" summary="resizing: the north-west corner is to be moved"/>
+      <entry name="s_resize" value="22" summary="resizing: the south border is to be moved"/>
+      <entry name="se_resize" value="23" summary="resizing: the south-east corner is to be moved"/>
+      <entry name="sw_resize" value="24" summary="resizing: the south-west corner is to be moved"/>
+      <entry name="w_resize" value="25" summary="resizing: the west border is to be moved"/>
+      <entry name="ew_resize" value="26" summary="resizing: the east and west borders are to be moved"/>
+      <entry name="ns_resize" value="27" summary="resizing: the north and south borders are to be moved"/>
+      <entry name="nesw_resize" value="28" summary="resizing: the north-east and south-west corners are to be moved"/>
+      <entry name="nwse_resize" value="29" summary="resizing: the north-west and south-east corners are to be moved"/>
+      <entry name="col_resize" value="30" summary="resizing: that the item/column can be resized horizontally"/>
+      <entry name="row_resize" value="31" summary="resizing: that the item/row can be resized vertically"/>
+      <entry name="all_scroll" value="32" summary="something can be scrolled in any direction"/>
+      <entry name="zoom_in" value="33" summary="something can be zoomed in"/>
+      <entry name="zoom_out" value="34" summary="something can be zoomed out"/>
+      <entry name="dnd_ask" value="35" summary="drag-and-drop: the user will select which action will be carried out (non-css value)" since="2"/>
+      <entry name="all_resize" value="36" summary="resizing: something can be moved or resized in any direction (non-css value)" since="2"/>
+    </enum>
+
+    <enum name="error">
+      <entry name="invalid_shape" value="1"
+        summary="the specified shape value is invalid"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the cursor shape device">
+        Destroy the cursor shape device.
+
+        The device cursor shape remains unchanged.
+      </description>
+    </request>
+
+    <request name="set_shape">
+      <description summary="set device cursor to the shape">
+        Sets the device cursor to the specified shape. The compositor will
+        change the cursor image based on the specified shape.
+
+        The cursor actually changes only if the input device focus is one of
+        the requesting client's surfaces. If any, the previous cursor image
+        (surface or shape) is replaced.
+
+        The "shape" argument must be a valid enum entry, otherwise the
+        invalid_shape protocol error is raised.
+
+        This is similar to the wl_pointer.set_cursor and
+        zwp_tablet_tool_v2.set_cursor requests, but this request accepts a
+        shape instead of contents in the form of a surface. Clients can mix
+        set_cursor and set_shape requests.
+
+        The serial parameter must match the latest wl_pointer.enter or
+        zwp_tablet_tool_v2.proximity_in serial number sent to the client.
+        Otherwise the request will be ignored.
+      </description>
+      <arg name="serial" type="uint" summary="serial number of the enter event"/>
+      <arg name="shape" type="uint" enum="shape"/>
+    </request>
+  </interface>
+</protocol>

--- a/deps/wayland/kde-shadow.xml
+++ b/deps/wayland/kde-shadow.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="shadow">
+  <copyright><![CDATA[
+    SPDX-FileCopyrightText: 2015 Martin Gräßlin
+
+    SPDX-License-Identifier: LGPL-2.1-or-later
+  ]]></copyright>
+  <interface name="org_kde_kwin_shadow_manager" version="2">
+      <request name="create">
+          <arg name="id" type="new_id" interface="org_kde_kwin_shadow"/>
+          <arg name="surface" type="object" interface="wl_surface"/>
+      </request>
+      <request name="unset">
+          <arg name="surface" type="object" interface="wl_surface"/>
+      </request>
+      <request name="destroy" type="destructor" since="2">
+          <description summary="Destroy the org_kde_kwin_shadow_manager">
+              Destroy the org_kde_kwin_shadow_manager object.
+          </description>
+      </request>
+  </interface>
+  <interface name="org_kde_kwin_shadow" version="2">
+      <request name="commit">
+      </request>
+      <request name="attach_left">
+          <arg name="buffer" type="object" interface="wl_buffer"/>
+      </request>
+      <request name="attach_top_left">
+          <arg name="buffer" type="object" interface="wl_buffer"/>
+      </request>
+      <request name="attach_top">
+          <arg name="buffer" type="object" interface="wl_buffer"/>
+      </request>
+      <request name="attach_top_right">
+          <arg name="buffer" type="object" interface="wl_buffer"/>
+      </request>
+      <request name="attach_right">
+          <arg name="buffer" type="object" interface="wl_buffer"/>
+      </request>
+      <request name="attach_bottom_right">
+          <arg name="buffer" type="object" interface="wl_buffer"/>
+      </request>
+      <request name="attach_bottom">
+          <arg name="buffer" type="object" interface="wl_buffer"/>
+      </request>
+      <request name="attach_bottom_left">
+          <arg name="buffer" type="object" interface="wl_buffer"/>
+      </request>
+      <request name="set_left_offset">
+          <arg name="offset" type="fixed"/>
+      </request>
+      <request name="set_top_offset">
+          <arg name="offset" type="fixed"/>
+      </request>
+      <request name="set_right_offset">
+          <arg name="offset" type="fixed"/>
+      </request>
+      <request name="set_bottom_offset">
+          <arg name="offset" type="fixed"/>
+      </request>
+      <request name="destroy" type="destructor" since="2">
+          <description summary="Destroy the org_kde_kwin_shadow">
+              Destroy the org_kde_kwin_shadow object. If the org_kde_kwin_shadow is
+              still set on a wl_surface the shadow will be immediately removed.
+              Prefer to first call the request unset on the org_kde_kwin_shadow_manager and
+              commit the wl_surface to apply the change.
+          </description>
+      </request>
+  </interface>
+</protocol>

--- a/deps/wayland/tablet-v2.xml
+++ b/deps/wayland/tablet-v2.xml
@@ -1,0 +1,1297 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="tablet_v2">
+
+  <copyright>
+    Copyright 2014 © Stephen "Lyude" Chandler Paul
+    Copyright 2015-2024 © Red Hat, Inc.
+
+    Permission is hereby granted, free of charge, to any person
+    obtaining a copy of this software and associated documentation files
+    (the "Software"), to deal in the Software without restriction,
+    including without limitation the rights to use, copy, modify, merge,
+    publish, distribute, sublicense, and/or sell copies of the Software,
+    and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the
+    next paragraph) shall be included in all copies or substantial
+    portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+    BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+    ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+  </copyright>
+
+  <description summary="Wayland protocol for graphics tablets">
+    This description provides a high-level overview of the interplay between
+    the interfaces defined this protocol. For details, see the protocol
+    specification.
+
+    More than one tablet may exist, and device-specifics matter. Tablets are
+    not represented by a single virtual device like wl_pointer. A client
+    binds to the tablet manager object which is just a proxy object. From
+    that, the client requests wp_tablet_manager.get_tablet_seat(wl_seat)
+    and that returns the actual interface that has all the tablets. With
+    this indirection, we can avoid merging wp_tablet into the actual Wayland
+    protocol, a long-term benefit.
+
+    The wp_tablet_seat sends a "tablet added" event for each tablet
+    connected. That event is followed by descriptive events about the
+    hardware; currently that includes events for name, vid/pid and
+    a wp_tablet.path event that describes a local path. This path can be
+    used to uniquely identify a tablet or get more information through
+    libwacom. Emulated or nested tablets can skip any of those, e.g. a
+    virtual tablet may not have a vid/pid. The sequence of descriptive
+    events is terminated by a wp_tablet.done event to signal that a client
+    may now finalize any initialization for that tablet.
+
+    Events from tablets require a tool in proximity. Tools are also managed
+    by the tablet seat; a "tool added" event is sent whenever a tool is new
+    to the compositor. That event is followed by a number of descriptive
+    events about the hardware; currently that includes capabilities,
+    hardware id and serial number, and tool type. Similar to the tablet
+    interface, a wp_tablet_tool.done event is sent to terminate that initial
+    sequence.
+
+    Any event from a tool happens on the wp_tablet_tool interface. When the
+    tool gets into proximity of the tablet, a proximity_in event is sent on
+    the wp_tablet_tool interface, listing the tablet and the surface. That
+    event is followed by a motion event with the coordinates. After that,
+    it's the usual motion, axis, button, etc. events. The protocol's
+    serialisation means events are grouped by wp_tablet_tool.frame events.
+
+    Two special events (that don't exist in X) are down and up. They signal
+    "tip touching the surface". For tablets without real proximity
+    detection, the sequence is: proximity_in, motion, down, frame.
+
+    When the tool leaves proximity, a proximity_out event is sent. If any
+    button is still down, a button release event is sent before this
+    proximity event. These button events are sent in the same frame as the
+    proximity event to signal to the client that the buttons were held when
+    the tool left proximity.
+
+    If the tool moves out of the surface but stays in proximity (i.e.
+    between windows), compositor-specific grab policies apply. This usually
+    means that the proximity-out is delayed until all buttons are released.
+
+    Moving a tool physically from one tablet to the other has no real effect
+    on the protocol, since we already have the tool object from the "tool
+    added" event. All the information is already there and the proximity
+    events on both tablets are all a client needs to reconstruct what
+    happened.
+
+    Some extra axes are normalized, i.e. the client knows the range as
+    specified in the protocol (e.g. [0, 65535]), the granularity however is
+    unknown. The current normalized axes are pressure, distance, and slider.
+
+    Other extra axes are in physical units as specified in the protocol.
+    The current extra axes with physical units are tilt, rotation and
+    wheel rotation.
+
+    Since tablets work independently of the pointer controlled by the mouse,
+    the focus handling is independent too and controlled by proximity.
+    The wp_tablet_tool.set_cursor request sets a tool-specific cursor.
+    This cursor surface may be the same as the mouse cursor, and it may be
+    the same across tools but it is possible to be more fine-grained. For
+    example, a client may set different cursors for the pen and eraser.
+
+    Tools are generally independent of tablets and it is
+    compositor-specific policy when a tool can be removed. Common approaches
+    will likely include some form of removing a tool when all tablets the
+    tool was used on are removed.
+  </description>
+
+  <interface name="zwp_tablet_manager_v2" version="2">
+    <description summary="controller object for graphic tablet devices">
+      An object that provides access to the graphics tablets available on this
+      system. All tablets are associated with a seat, to get access to the
+      actual tablets, use wp_tablet_manager.get_tablet_seat.
+    </description>
+
+    <request name="get_tablet_seat">
+      <description summary="get the tablet seat">
+	Get the wp_tablet_seat object for the given seat. This object
+	provides access to all graphics tablets in this seat.
+      </description>
+      <arg name="tablet_seat" type="new_id" interface="zwp_tablet_seat_v2"/>
+      <arg name="seat" type="object" interface="wl_seat" summary="The wl_seat object to retrieve the tablets for" />
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="release the memory for the tablet manager object">
+	Destroy the wp_tablet_manager object. Objects created from this
+	object are unaffected and should be destroyed separately.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwp_tablet_seat_v2" version="2">
+    <description summary="controller object for graphic tablet devices of a seat">
+      An object that provides access to the graphics tablets available on this
+      seat. After binding to this interface, the compositor sends a set of
+      wp_tablet_seat.tablet_added and wp_tablet_seat.tool_added events.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="release the memory for the tablet seat object">
+	Destroy the wp_tablet_seat object. Objects created from this
+	object are unaffected and should be destroyed separately.
+      </description>
+    </request>
+
+    <event name="tablet_added">
+      <description summary="new device notification">
+	This event is sent whenever a new tablet becomes available on this
+	seat. This event only provides the object id of the tablet, any
+	static information about the tablet (device name, vid/pid, etc.) is
+	sent through the wp_tablet interface.
+      </description>
+      <arg name="id" type="new_id" interface="zwp_tablet_v2" summary="the newly added graphics tablet"/>
+    </event>
+
+    <event name="tool_added">
+      <description summary="a new tool has been used with a tablet">
+	This event is sent whenever a tool that has not previously been used
+	with a tablet comes into use. This event only provides the object id
+	of the tool; any static information about the tool (capabilities,
+	type, etc.) is sent through the wp_tablet_tool interface.
+      </description>
+      <arg name="id" type="new_id" interface="zwp_tablet_tool_v2" summary="the newly added tablet tool"/>
+    </event>
+
+    <event name="pad_added">
+      <description summary="new pad notification">
+	This event is sent whenever a new pad is known to the system. Typically,
+	pads are physically attached to tablets and a pad_added event is
+	sent immediately after the wp_tablet_seat.tablet_added.
+	However, some standalone pad devices logically attach to tablets at
+	runtime, and the client must wait for wp_tablet_pad.enter to know
+	the tablet a pad is attached to.
+
+	This event only provides the object id of the pad. All further
+	features (buttons, strips, rings) are sent through the wp_tablet_pad
+	interface.
+      </description>
+      <arg name="id" type="new_id" interface="zwp_tablet_pad_v2" summary="the newly added pad"/>
+    </event>
+  </interface>
+
+  <interface name="zwp_tablet_tool_v2" version="2">
+    <description summary="a physical tablet tool">
+      An object that represents a physical tool that has been, or is
+      currently in use with a tablet in this seat. Each wp_tablet_tool
+      object stays valid until the client destroys it; the compositor
+      reuses the wp_tablet_tool object to indicate that the object's
+      respective physical tool has come into proximity of a tablet again.
+
+      A wp_tablet_tool object's relation to a physical tool depends on the
+      tablet's ability to report serial numbers. If the tablet supports
+      this capability, then the object represents a specific physical tool
+      and can be identified even when used on multiple tablets.
+
+      A tablet tool has a number of static characteristics, e.g. tool type,
+      hardware_serial and capabilities. These capabilities are sent in an
+      event sequence after the wp_tablet_seat.tool_added event before any
+      actual events from this tool. This initial event sequence is
+      terminated by a wp_tablet_tool.done event.
+
+      Tablet tool events are grouped by wp_tablet_tool.frame events.
+      Any events received before a wp_tablet_tool.frame event should be
+      considered part of the same hardware state change.
+    </description>
+
+    <request name="set_cursor">
+      <description summary="set the tablet tool's surface">
+	Sets the surface of the cursor used for this tool on the given
+	tablet. This request only takes effect if the tool is in proximity
+	of one of the requesting client's surfaces or the surface parameter
+	is the current pointer surface. If there was a previous surface set
+	with this request it is replaced. If surface is NULL, the cursor
+	image is hidden.
+
+	The parameters hotspot_x and hotspot_y define the position of the
+	pointer surface relative to the pointer location. Its top-left corner
+	is always at (x, y) - (hotspot_x, hotspot_y), where (x, y) are the
+	coordinates of the pointer location, in surface-local coordinates.
+
+	On surface.attach requests to the pointer surface, hotspot_x and
+	hotspot_y are decremented by the x and y parameters passed to the
+	request. Attach must be confirmed by wl_surface.commit as usual.
+
+	The hotspot can also be updated by passing the currently set pointer
+	surface to this request with new values for hotspot_x and hotspot_y.
+
+	The current and pending input regions of the wl_surface are cleared,
+	and wl_surface.set_input_region is ignored until the wl_surface is no
+	longer used as the cursor. When the use as a cursor ends, the current
+	and pending input regions become undefined, and the wl_surface is
+	unmapped.
+
+	This request gives the surface the role of a wp_tablet_tool cursor. A
+	surface may only ever be used as the cursor surface for one
+	wp_tablet_tool. If the surface already has another role or has
+	previously been used as cursor surface for a different tool, a
+	protocol error is raised.
+      </description>
+      <arg name="serial" type="uint" summary="serial of the proximity_in event"/>
+      <arg name="surface" type="object" interface="wl_surface" allow-null="true"/>
+      <arg name="hotspot_x" type="int" summary="surface-local x coordinate"/>
+      <arg name="hotspot_y" type="int" summary="surface-local y coordinate"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the tool object">
+	This destroys the client's resource for this tool object.
+      </description>
+    </request>
+
+    <enum name="type">
+      <description summary="a physical tool type">
+	Describes the physical type of a tool. The physical type of a tool
+	generally defines its base usage.
+
+	The mouse tool represents a mouse-shaped tool that is not a relative
+	device but bound to the tablet's surface, providing absolute
+	coordinates.
+
+	The lens tool is a mouse-shaped tool with an attached lens to
+	provide precision focus.
+      </description>
+      <entry name="pen" value="0x140" summary="Pen"/>
+      <entry name="eraser" value="0x141" summary="Eraser"/>
+      <entry name="brush" value="0x142" summary="Brush"/>
+      <entry name="pencil" value="0x143" summary="Pencil"/>
+      <entry name="airbrush" value="0x144" summary="Airbrush"/>
+      <entry name="finger" value="0x145" summary="Finger"/>
+      <entry name="mouse" value="0x146" summary="Mouse"/>
+      <entry name="lens" value="0x147" summary="Lens"/>
+    </enum>
+
+    <event name="type">
+      <description summary="tool type">
+	The tool type is the high-level type of the tool and usually decides
+	the interaction expected from this tool.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet_tool.done event.
+      </description>
+      <arg name="tool_type" type="uint" enum="type" summary="the physical tool type"/>
+    </event>
+
+    <event name="hardware_serial">
+      <description summary="unique hardware serial number of the tool">
+	If the physical tool can be identified by a unique 64-bit serial
+	number, this event notifies the client of this serial number.
+
+	If multiple tablets are available in the same seat and the tool is
+	uniquely identifiable by the serial number, that tool may move
+	between tablets.
+
+	Otherwise, if the tool has no serial number and this event is
+	missing, the tool is tied to the tablet it first comes into
+	proximity with. Even if the physical tool is used on multiple
+	tablets, separate wp_tablet_tool objects will be created, one per
+	tablet.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet_tool.done event.
+      </description>
+      <arg name="hardware_serial_hi" type="uint" summary="the unique serial number of the tool, most significant bits"/>
+      <arg name="hardware_serial_lo" type="uint" summary="the unique serial number of the tool, least significant bits"/>
+    </event>
+
+    <event name="hardware_id_wacom">
+      <description summary="hardware id notification in Wacom's format">
+	This event notifies the client of a hardware id available on this tool.
+
+	The hardware id is a device-specific 64-bit id that provides extra
+	information about the tool in use, beyond the wl_tool.type
+	enumeration. The format of the id is specific to tablets made by
+	Wacom Inc. For example, the hardware id of a Wacom Grip
+	Pen (a stylus) is 0x802.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet_tool.done event.
+      </description>
+      <arg name="hardware_id_hi" type="uint" summary="the hardware id, most significant bits"/>
+      <arg name="hardware_id_lo" type="uint" summary="the hardware id, least significant bits"/>
+    </event>
+
+    <enum name="capability">
+      <description summary="capability flags for a tool">
+	Describes extra capabilities on a tablet.
+
+	Any tool must provide x and y values, extra axes are
+	device-specific.
+      </description>
+      <entry name="tilt" value="1" summary="Tilt axes"/>
+      <entry name="pressure" value="2" summary="Pressure axis"/>
+      <entry name="distance" value="3" summary="Distance axis"/>
+      <entry name="rotation" value="4" summary="Z-rotation axis"/>
+      <entry name="slider" value="5" summary="Slider axis"/>
+      <entry name="wheel" value="6" summary="Wheel axis"/>
+    </enum>
+
+    <event name="capability">
+      <description summary="tool capability notification">
+	This event notifies the client of any capabilities of this tool,
+	beyond the main set of x/y axes and tip up/down detection.
+
+	One event is sent for each extra capability available on this tool.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet_tool.done event.
+      </description>
+      <arg name="capability" type="uint" enum="capability" summary="the capability"/>
+    </event>
+
+    <event name="done">
+      <description summary="tool description events sequence complete">
+	This event signals the end of the initial burst of descriptive
+	events. A client may consider the static description of the tool to
+	be complete and finalize initialization of the tool.
+      </description>
+    </event>
+
+    <event name="removed">
+      <description summary="tool removed">
+	This event is sent when the tool is removed from the system and will
+	send no further events. Should the physical tool come back into
+	proximity later, a new wp_tablet_tool object will be created.
+
+	It is compositor-dependent when a tool is removed. A compositor may
+	remove a tool on proximity out, tablet removal or any other reason.
+	A compositor may also keep a tool alive until shutdown.
+
+	If the tool is currently in proximity, a proximity_out event will be
+	sent before the removed event. See wp_tablet_tool.proximity_out for
+	the handling of any buttons logically down.
+
+	When this event is received, the client must wp_tablet_tool.destroy
+	the object.
+      </description>
+    </event>
+
+    <event name="proximity_in">
+      <description summary="proximity in event">
+	Notification that this tool is focused on a certain surface.
+
+	This event can be received when the tool has moved from one surface to
+	another, or when the tool has come back into proximity above the
+	surface.
+
+	If any button is logically down when the tool comes into proximity,
+	the respective button event is sent after the proximity_in event but
+	within the same frame as the proximity_in event.
+      </description>
+      <arg name="serial" type="uint"/>
+      <arg name="tablet" type="object" interface="zwp_tablet_v2" summary="The tablet the tool is in proximity of"/>
+      <arg name="surface" type="object" interface="wl_surface" summary="The current surface the tablet tool is over"/>
+    </event>
+
+    <event name="proximity_out">
+      <description summary="proximity out event">
+	Notification that this tool has either left proximity, or is no
+	longer focused on a certain surface.
+
+	When the tablet tool leaves proximity of the tablet, button release
+	events are sent for each button that was held down at the time of
+	leaving proximity. These events are sent before the proximity_out
+	event but within the same wp_tablet.frame.
+
+	If the tool stays within proximity of the tablet, but the focus
+	changes from one surface to another, a button release event may not
+	be sent until the button is actually released or the tool leaves the
+	proximity of the tablet.
+      </description>
+    </event>
+
+    <event name="down">
+      <description summary="tablet tool is making contact">
+	Sent whenever the tablet tool comes in contact with the surface of the
+	tablet.
+
+	If the tool is already in contact with the tablet when entering the
+	input region, the client owning said region will receive a
+	wp_tablet.proximity_in event, followed by a wp_tablet.down
+	event and a wp_tablet.frame event.
+
+	Note that this event describes logical contact, not physical
+	contact. On some devices, a compositor may not consider a tool in
+	logical contact until a minimum physical pressure threshold is
+	exceeded.
+      </description>
+      <arg name="serial" type="uint"/>
+    </event>
+
+    <event name="up">
+      <description summary="tablet tool is no longer making contact">
+	Sent whenever the tablet tool stops making contact with the surface of
+	the tablet, or when the tablet tool moves out of the input region
+	and the compositor grab (if any) is dismissed.
+
+	If the tablet tool moves out of the input region while in contact
+	with the surface of the tablet and the compositor does not have an
+	ongoing grab on the surface, the client owning said region will
+	receive a wp_tablet.up event, followed by a wp_tablet.proximity_out
+	event and a wp_tablet.frame event. If the compositor has an ongoing
+	grab on this device, this event sequence is sent whenever the grab
+	is dismissed in the future.
+
+	Note that this event describes logical contact, not physical
+	contact. On some devices, a compositor may not consider a tool out
+	of logical contact until physical pressure falls below a specific
+	threshold.
+      </description>
+    </event>
+
+    <event name="motion">
+      <description summary="motion event">
+	Sent whenever a tablet tool moves.
+      </description>
+      <arg name="x" type="fixed" summary="surface-local x coordinate"/>
+      <arg name="y" type="fixed" summary="surface-local y coordinate"/>
+    </event>
+
+    <event name="pressure">
+      <description summary="pressure change event">
+	Sent whenever the pressure axis on a tool changes. The value of this
+	event is normalized to a value between 0 and 65535.
+
+	Note that pressure may be nonzero even when a tool is not in logical
+	contact. See the down and up events for more details.
+      </description>
+      <arg name="pressure" type="uint" summary="The current pressure value"/>
+    </event>
+
+    <event name="distance">
+      <description summary="distance change event">
+	Sent whenever the distance axis on a tool changes. The value of this
+	event is normalized to a value between 0 and 65535.
+
+	Note that distance may be nonzero even when a tool is not in logical
+	contact. See the down and up events for more details.
+      </description>
+      <arg name="distance" type="uint" summary="The current distance value"/>
+    </event>
+
+    <event name="tilt">
+      <description summary="tilt change event">
+	Sent whenever one or both of the tilt axes on a tool change. Each tilt
+	value is in degrees, relative to the z-axis of the tablet.
+	The angle is positive when the top of a tool tilts along the
+	positive x or y axis.
+      </description>
+      <arg name="tilt_x" type="fixed" summary="The current value of the X tilt axis"/>
+      <arg name="tilt_y" type="fixed" summary="The current value of the Y tilt axis"/>
+    </event>
+
+    <event name="rotation">
+      <description summary="z-rotation change event">
+	Sent whenever the z-rotation axis on the tool changes. The
+	rotation value is in degrees clockwise from the tool's
+	logical neutral position.
+      </description>
+      <arg name="degrees" type="fixed" summary="The current rotation of the Z axis"/>
+    </event>
+
+    <event name="slider">
+      <description summary="Slider position change event">
+	Sent whenever the slider position on the tool changes. The
+	value is normalized between -65535 and 65535, with 0 as the logical
+	neutral position of the slider.
+
+	The slider is available on e.g. the Wacom Airbrush tool.
+      </description>
+      <arg name="position" type="int" summary="The current position of slider"/>
+    </event>
+
+    <event name="wheel">
+      <description summary="Wheel delta event">
+	Sent whenever the wheel on the tool emits an event. This event
+	contains two values for the same axis change. The degrees value is
+	in the same orientation as the wl_pointer.vertical_scroll axis. The
+	clicks value is in discrete logical clicks of the mouse wheel. This
+	value may be zero if the movement of the wheel was less
+	than one logical click.
+
+	Clients should choose either value and avoid mixing degrees and
+	clicks. The compositor may accumulate values smaller than a logical
+	click and emulate click events when a certain threshold is met.
+	Thus, wl_tablet_tool.wheel events with non-zero clicks values may
+	have different degrees values.
+      </description>
+      <arg name="degrees" type="fixed" summary="The wheel delta in degrees"/>
+      <arg name="clicks" type="int" summary="The wheel delta in discrete clicks"/>
+    </event>
+
+    <enum name="button_state">
+      <description summary="physical button state">
+	Describes the physical state of a button that produced the button event.
+      </description>
+      <entry name="released" value="0" summary="button is not pressed"/>
+      <entry name="pressed" value="1" summary="button is pressed"/>
+    </enum>
+
+    <event name="button">
+      <description summary="button event">
+	Sent whenever a button on the tool is pressed or released.
+
+	If a button is held down when the tool moves in or out of proximity,
+	button events are generated by the compositor. See
+	wp_tablet_tool.proximity_in and wp_tablet_tool.proximity_out for
+	details.
+      </description>
+      <arg name="serial" type="uint"/>
+      <arg name="button" type="uint" summary="The button whose state has changed"/>
+      <arg name="state" type="uint" enum="button_state" summary="Whether the button was pressed or released"/>
+    </event>
+
+    <event name="frame">
+      <description summary="frame event">
+	Marks the end of a series of axis and/or button updates from the
+	tablet. The Wayland protocol requires axis updates to be sent
+	sequentially, however all events within a frame should be considered
+	one hardware event.
+      </description>
+      <arg name="time" type="uint" summary="The time of the event with millisecond granularity"/>
+    </event>
+
+    <enum name="error">
+      <entry name="role" value="0" summary="given wl_surface has another role"/>
+    </enum>
+  </interface>
+
+  <interface name="zwp_tablet_v2" version="2">
+    <description summary="graphics tablet device">
+      The wp_tablet interface represents one graphics tablet device. The
+      tablet interface itself does not generate events; all events are
+      generated by wp_tablet_tool objects when in proximity above a tablet.
+
+      A tablet has a number of static characteristics, e.g. device name and
+      pid/vid. These capabilities are sent in an event sequence after the
+      wp_tablet_seat.tablet_added event. This initial event sequence is
+      terminated by a wp_tablet.done event.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the tablet object">
+	This destroys the client's resource for this tablet object.
+      </description>
+    </request>
+
+    <event name="name">
+      <description summary="tablet device name">
+        A descriptive name for the tablet device.
+
+	If the device has no descriptive name, this event is not sent.
+
+	This event is sent in the initial burst of events before the
+        wp_tablet.done event.
+      </description>
+      <arg name="name" type="string" summary="the device name"/>
+    </event>
+
+    <event name="id">
+      <description summary="tablet device vendor/product id">
+	The vendor and product IDs for the tablet device.
+
+	The interpretation of the id depends on the wp_tablet.bustype.
+	Prior to version v2 of this protocol, the id was implied to be a USB
+	vendor and product ID. If no wp_tablet.bustype is sent, the ID
+	is to be interpreted as USB vendor and product ID.
+
+	If the device has no vendor/product ID, this event is not sent.
+	This can happen for virtual devices or non-USB devices, for instance.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet.done event.
+      </description>
+      <arg name="vid" type="uint" summary="vendor id"/>
+      <arg name="pid" type="uint" summary="product id"/>
+    </event>
+
+    <event name="path">
+      <description summary="path to the device">
+	A system-specific device path that indicates which device is behind
+	this wp_tablet. This information may be used to gather additional
+	information about the device, e.g. through libwacom.
+
+	A device may have more than one device path. If so, multiple
+	wp_tablet.path events are sent. A device may be emulated and not
+	have a device path, and in that case this event will not be sent.
+
+	The format of the path is unspecified, it may be a device node, a
+	sysfs path, or some other identifier. It is up to the client to
+	identify the string provided.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet.done event.
+      </description>
+      <arg name="path" type="string" summary="path to local device"/>
+    </event>
+
+    <event name="done">
+      <description summary="tablet description events sequence complete">
+	This event is sent immediately to signal the end of the initial
+	burst of descriptive events. A client may consider the static
+	description of the tablet to be complete and finalize initialization
+	of the tablet.
+      </description>
+    </event>
+
+    <event name="removed">
+      <description summary="tablet removed event">
+	Sent when the tablet has been removed from the system. When a tablet
+	is removed, some tools may be removed.
+
+	When this event is received, the client must wp_tablet.destroy
+	the object.
+      </description>
+    </event>
+
+    <!-- Version 2 additions -->
+
+    <enum name="bustype" since="2">
+      <description summary="bus type ">
+	Describes the bus types this tablet is connected to.
+      </description>
+      <entry name="usb" value="3" summary="USB"/>
+      <entry name="bluetooth" value="5" summary="Bluetooth"/>
+      <entry name="virtual" value="6" summary="Virtual"/>
+      <entry name="serial" value="17" summary="Serial"/>
+      <entry name="i2c" value="24" summary="I2C"/>
+    </enum>
+
+    <event name="bustype" since="2">
+      <description summary="tablet device bus type">
+	The bustype argument is one of the BUS_ defines in the Linux kernel's
+	linux/input.h
+
+	If the device has no known bustype or the bustype cannot be
+	queried, this event is not sent.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet.done event.
+      </description>
+      <arg name="bustype" type="uint" enum="bustype" summary="bus type"/>
+    </event>
+  </interface>
+
+  <interface name="zwp_tablet_pad_ring_v2" version="2">
+    <description summary="pad ring">
+      A circular interaction area, such as the touch ring on the Wacom Intuos
+      Pro series tablets.
+
+      Events on a ring are logically grouped by the wl_tablet_pad_ring.frame
+      event.
+    </description>
+
+    <request name="set_feedback">
+      <description summary="set compositor feedback">
+	Request that the compositor use the provided feedback string
+	associated with this ring. This request should be issued immediately
+	after a wp_tablet_pad_group.mode_switch event from the corresponding
+	group is received, or whenever the ring is mapped to a different
+	action. See wp_tablet_pad_group.mode_switch for more details.
+
+	Clients are encouraged to provide context-aware descriptions for
+	the actions associated with the ring; compositors may use this
+	information to offer visual feedback about the button layout
+	(eg. on-screen displays).
+
+	The provided string 'description' is a UTF-8 encoded string to be
+	associated with this ring, and is considered user-visible; general
+	internationalization rules apply.
+
+	The serial argument will be that of the last
+	wp_tablet_pad_group.mode_switch event received for the group of this
+	ring. Requests providing other serials than the most recent one will be
+	ignored.
+      </description>
+      <arg name="description" type="string" summary="ring description"/>
+      <arg name="serial" type="uint" summary="serial of the mode switch event"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the ring object">
+	This destroys the client's resource for this ring object.
+      </description>
+    </request>
+
+    <enum name="source">
+      <description summary="ring axis source">
+	Describes the source types for ring events. This indicates to the
+	client how a ring event was physically generated; a client may
+	adjust the user interface accordingly. For example, events
+	from a "finger" source may trigger kinetic scrolling.
+      </description>
+      <entry name="finger" value="1" summary="finger"/>
+    </enum>
+
+    <event name="source">
+      <description summary="ring event source">
+	Source information for ring events.
+
+	This event does not occur on its own. It is sent before a
+	wp_tablet_pad_ring.frame event and carries the source information
+	for all events within that frame.
+
+	The source specifies how this event was generated. If the source is
+	wp_tablet_pad_ring.source.finger, a wp_tablet_pad_ring.stop event
+	will be sent when the user lifts the finger off the device.
+
+	This event is optional. If the source is unknown for an interaction,
+	no event is sent.
+      </description>
+      <arg name="source" type="uint" enum="source" summary="the event source"/>
+    </event>
+
+    <event name="angle">
+      <description summary="angle changed">
+	Sent whenever the angle on a ring changes.
+
+	The angle is provided in degrees clockwise from the logical
+	north of the ring in the pad's current rotation.
+      </description>
+      <arg name="degrees" type="fixed" summary="the current angle in degrees"/>
+    </event>
+
+    <event name="stop">
+      <description summary="interaction stopped">
+	Stop notification for ring events.
+
+	For some wp_tablet_pad_ring.source types, a wp_tablet_pad_ring.stop
+	event is sent to notify a client that the interaction with the ring
+	has terminated. This enables the client to implement kinetic scrolling.
+	See the wp_tablet_pad_ring.source documentation for information on
+	when this event may be generated.
+
+	Any wp_tablet_pad_ring.angle events with the same source after this
+	event should be considered as the start of a new interaction.
+      </description>
+    </event>
+
+    <event name="frame">
+      <description summary="end of a ring event sequence">
+	Indicates the end of a set of ring events that logically belong
+	together. A client is expected to accumulate the data in all events
+	within the frame before proceeding.
+
+	All wp_tablet_pad_ring events before a wp_tablet_pad_ring.frame event belong
+	logically together. For example, on termination of a finger interaction
+	on a ring the compositor will send a wp_tablet_pad_ring.source event,
+	a wp_tablet_pad_ring.stop event and a wp_tablet_pad_ring.frame event.
+
+	A wp_tablet_pad_ring.frame event is sent for every logical event
+	group, even if the group only contains a single wp_tablet_pad_ring
+	event. Specifically, a client may get a sequence: angle, frame,
+	angle, frame, etc.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+    </event>
+  </interface>
+
+  <interface name="zwp_tablet_pad_strip_v2" version="2">
+    <description summary="pad strip">
+      A linear interaction area, such as the strips found in Wacom Cintiq
+      models.
+
+      Events on a strip are logically grouped by the wl_tablet_pad_strip.frame
+      event.
+    </description>
+
+    <request name="set_feedback">
+      <description summary="set compositor feedback">
+	Requests the compositor to use the provided feedback string
+	associated with this strip. This request should be issued immediately
+	after a wp_tablet_pad_group.mode_switch event from the corresponding
+	group is received, or whenever the strip is mapped to a different
+	action. See wp_tablet_pad_group.mode_switch for more details.
+
+	Clients are encouraged to provide context-aware descriptions for
+	the actions associated with the strip, and compositors may use this
+	information to offer visual feedback about the button layout
+	(eg. on-screen displays).
+
+	The provided string 'description' is a UTF-8 encoded string to be
+	associated with this ring, and is considered user-visible; general
+	internationalization rules apply.
+
+	The serial argument will be that of the last
+	wp_tablet_pad_group.mode_switch event received for the group of this
+	strip. Requests providing other serials than the most recent one will be
+	ignored.
+      </description>
+      <arg name="description" type="string" summary="strip description"/>
+      <arg name="serial" type="uint" summary="serial of the mode switch event"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the strip object">
+	This destroys the client's resource for this strip object.
+      </description>
+    </request>
+
+    <enum name="source">
+      <description summary="strip axis source">
+	Describes the source types for strip events. This indicates to the
+	client how a strip event was physically generated; a client may
+	adjust the user interface accordingly. For example, events
+	from a "finger" source may trigger kinetic scrolling.
+      </description>
+      <entry name="finger" value="1" summary="finger"/>
+    </enum>
+
+    <event name="source">
+      <description summary="strip event source">
+	Source information for strip events.
+
+	This event does not occur on its own. It is sent before a
+	wp_tablet_pad_strip.frame event and carries the source information
+	for all events within that frame.
+
+	The source specifies how this event was generated. If the source is
+	wp_tablet_pad_strip.source.finger, a wp_tablet_pad_strip.stop event
+	will be sent when the user lifts their finger off the device.
+
+	This event is optional. If the source is unknown for an interaction,
+	no event is sent.
+      </description>
+      <arg name="source" type="uint" enum="source" summary="the event source"/>
+    </event>
+
+    <event name="position">
+      <description summary="position changed">
+	Sent whenever the position on a strip changes.
+
+	The position is normalized to a range of [0, 65535], the 0-value
+	represents the top-most and/or left-most position of the strip in
+	the pad's current rotation.
+      </description>
+      <arg name="position" type="uint" summary="the current position"/>
+    </event>
+
+    <event name="stop">
+      <description summary="interaction stopped">
+	Stop notification for strip events.
+
+	For some wp_tablet_pad_strip.source types, a wp_tablet_pad_strip.stop
+	event is sent to notify a client that the interaction with the strip
+	has terminated. This enables the client to implement kinetic
+	scrolling. See the wp_tablet_pad_strip.source documentation for
+	information on when this event may be generated.
+
+	Any wp_tablet_pad_strip.position events with the same source after this
+	event should be considered as the start of a new interaction.
+      </description>
+    </event>
+
+    <event name="frame">
+      <description summary="end of a strip event sequence">
+	Indicates the end of a set of events that represent one logical
+	hardware strip event. A client is expected to accumulate the data
+	in all events within the frame before proceeding.
+
+	All wp_tablet_pad_strip events before a wp_tablet_pad_strip.frame event belong
+	logically together. For example, on termination of a finger interaction
+	on a strip the compositor will send a wp_tablet_pad_strip.source event,
+	a wp_tablet_pad_strip.stop event and a wp_tablet_pad_strip.frame
+	event.
+
+	A wp_tablet_pad_strip.frame event is sent for every logical event
+	group, even if the group only contains a single wp_tablet_pad_strip
+	event. Specifically, a client may get a sequence: position, frame,
+	position, frame, etc.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+    </event>
+  </interface>
+
+  <interface name="zwp_tablet_pad_group_v2" version="2">
+    <description summary="a set of buttons, rings and strips">
+      A pad group describes a distinct (sub)set of buttons, rings and strips
+      present in the tablet. The criteria of this grouping is usually positional,
+      eg. if a tablet has buttons on the left and right side, 2 groups will be
+      presented. The physical arrangement of groups is undisclosed and may
+      change on the fly.
+
+      Pad groups will announce their features during pad initialization. Between
+      the corresponding wp_tablet_pad.group event and wp_tablet_pad_group.done, the
+      pad group will announce the buttons, rings and strips contained in it,
+      plus the number of supported modes.
+
+      Modes are a mechanism to allow multiple groups of actions for every element
+      in the pad group. The number of groups and available modes in each is
+      persistent across device plugs. The current mode is user-switchable, it
+      will be announced through the wp_tablet_pad_group.mode_switch event both
+      whenever it is switched, and after wp_tablet_pad.enter.
+
+      The current mode logically applies to all elements in the pad group,
+      although it is at clients' discretion whether to actually perform different
+      actions, and/or issue the respective .set_feedback requests to notify the
+      compositor. See the wp_tablet_pad_group.mode_switch event for more details.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the pad object">
+	Destroy the wp_tablet_pad_group object. Objects created from this object
+	are unaffected and should be destroyed separately.
+      </description>
+    </request>
+
+    <event name="buttons">
+      <description summary="buttons announced">
+	Sent on wp_tablet_pad_group initialization to announce the available
+	buttons in the group. Button indices start at 0, a button may only be
+	in one group at a time.
+
+	This event is first sent in the initial burst of events before the
+	wp_tablet_pad_group.done event.
+
+	Some buttons are reserved by the compositor. These buttons may not be
+	assigned to any wp_tablet_pad_group. Compositors may broadcast this
+	event in the case of changes to the mapping of these reserved buttons.
+	If the compositor happens to reserve all buttons in a group, this event
+	will be sent with an empty array.
+      </description>
+      <arg name="buttons" type="array" summary="buttons in this group"/>
+    </event>
+
+    <event name="ring">
+      <description summary="ring announced">
+	Sent on wp_tablet_pad_group initialization to announce available rings.
+	One event is sent for each ring available on this pad group.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet_pad_group.done event.
+      </description>
+      <arg name="ring" type="new_id" interface="zwp_tablet_pad_ring_v2"/>
+    </event>
+
+    <event name="strip">
+      <description summary="strip announced">
+	Sent on wp_tablet_pad initialization to announce available strips.
+	One event is sent for each strip available on this pad group.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet_pad_group.done event.
+      </description>
+      <arg name="strip" type="new_id" interface="zwp_tablet_pad_strip_v2"/>
+    </event>
+
+    <event name="modes">
+      <description summary="mode-switch ability announced">
+	Sent on wp_tablet_pad_group initialization to announce that the pad
+	group may switch between modes. A client may use a mode to store a
+	specific configuration for buttons, rings and strips and use the
+	wl_tablet_pad_group.mode_switch event to toggle between these
+	configurations. Mode indices start at 0.
+
+	Switching modes is compositor-dependent. See the
+	wp_tablet_pad_group.mode_switch event for more details.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet_pad_group.done event. This event is only sent when more than
+	more than one mode is available.
+      </description>
+      <arg name="modes" type="uint" summary="the number of modes"/>
+    </event>
+
+    <event name="done">
+      <description summary="tablet group description events sequence complete">
+	This event is sent immediately to signal the end of the initial
+	burst of descriptive events. A client may consider the static
+	description of the tablet to be complete and finalize initialization
+	of the tablet group.
+      </description>
+    </event>
+
+    <event name="mode_switch">
+      <description summary="mode switch event">
+	Notification that the mode was switched.
+
+	A mode applies to all buttons, rings, strips and dials in a group
+	simultaneously, but a client is not required to assign different actions
+	for each mode. For example, a client may have mode-specific button
+	mappings but map the ring to vertical scrolling in all modes. Mode
+	indices start at 0.
+
+	Switching modes is compositor-dependent. The compositor may provide
+	visual cues to the user about the mode, e.g. by toggling LEDs on
+	the tablet device. Mode-switching may be software-controlled or
+	controlled by one or more physical buttons. For example, on a Wacom
+	Intuos Pro, the button inside the ring may be assigned to switch
+	between modes.
+
+	The compositor will also send this event after wp_tablet_pad.enter on
+	each group in order to notify of the current mode. Groups that only
+	feature one mode will use mode=0 when emitting this event.
+
+	If a button action in the new mode differs from the action in the
+	previous mode, the client should immediately issue a
+	wp_tablet_pad.set_feedback request for each changed button.
+
+	If a ring, strip or dial action in the new mode differs from the action
+	in the previous mode, the client should immediately issue a
+	wp_tablet_ring.set_feedback, wp_tablet_strip.set_feedback or
+	wp_tablet_dial.set_feedback request for each changed ring, strip or dial.
+      </description>
+      <arg name="time" type="uint" summary="the time of the event with millisecond granularity"/>
+      <arg name="serial" type="uint"/>
+      <arg name="mode" type="uint" summary="the new mode of the pad"/>
+    </event>
+
+    <!-- Version 2 additions -->
+
+    <event name="dial" since="2">
+      <description summary="dial announced">
+	Sent on wp_tablet_pad initialization to announce available dials.
+	One event is sent for each dial available on this pad group.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet_pad_group.done event.
+      </description>
+      <arg name="dial" type="new_id" interface="zwp_tablet_pad_dial_v2"/>
+    </event>
+  </interface>
+
+  <interface name="zwp_tablet_pad_v2" version="2">
+    <description summary="a set of buttons, rings, strips and dials">
+      A pad device is a set of buttons, rings, strips and dials
+      usually physically present on the tablet device itself. Some
+      exceptions exist where the pad device is physically detached, e.g. the
+      Wacom ExpressKey Remote.
+
+      Pad devices have no axes that control the cursor and are generally
+      auxiliary devices to the tool devices used on the tablet surface.
+
+      A pad device has a number of static characteristics, e.g. the number
+      of rings. These capabilities are sent in an event sequence after the
+      wp_tablet_seat.pad_added event before any actual events from this pad.
+      This initial event sequence is terminated by a wp_tablet_pad.done
+      event.
+
+      All pad features (buttons, rings, strips and dials) are logically divided into
+      groups and all pads have at least one group. The available groups are
+      notified through the wp_tablet_pad.group event; the compositor will
+      emit one event per group before emitting wp_tablet_pad.done.
+
+      Groups may have multiple modes. Modes allow clients to map multiple
+      actions to a single pad feature. Only one mode can be active per group,
+      although different groups may have different active modes.
+    </description>
+
+    <request name="set_feedback">
+      <description summary="set compositor feedback">
+	Requests the compositor to use the provided feedback string
+	associated with this button. This request should be issued immediately
+	after a wp_tablet_pad_group.mode_switch event from the corresponding
+	group is received, or whenever a button is mapped to a different
+	action. See wp_tablet_pad_group.mode_switch for more details.
+
+	Clients are encouraged to provide context-aware descriptions for
+	the actions associated with each button, and compositors may use
+	this information to offer visual feedback on the button layout
+	(e.g. on-screen displays).
+
+	Button indices start at 0. Setting the feedback string on a button
+	that is reserved by the compositor (i.e. not belonging to any
+	wp_tablet_pad_group) does not generate an error but the compositor
+	is free to ignore the request.
+
+	The provided string 'description' is a UTF-8 encoded string to be
+	associated with this ring, and is considered user-visible; general
+	internationalization rules apply.
+
+	The serial argument will be that of the last
+	wp_tablet_pad_group.mode_switch event received for the group of this
+	button. Requests providing other serials than the most recent one will
+	be ignored.
+      </description>
+      <arg name="button" type="uint" summary="button index"/>
+      <arg name="description" type="string" summary="button description"/>
+      <arg name="serial" type="uint" summary="serial of the mode switch event"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the pad object">
+	Destroy the wp_tablet_pad object. Objects created from this object
+	are unaffected and should be destroyed separately.
+      </description>
+    </request>
+
+    <event name="group">
+      <description summary="group announced">
+	Sent on wp_tablet_pad initialization to announce available groups.
+	One event is sent for each pad group available.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet_pad.done event. At least one group will be announced.
+      </description>
+      <arg name="pad_group" type="new_id" interface="zwp_tablet_pad_group_v2"/>
+    </event>
+
+    <event name="path">
+      <description summary="path to the device">
+	A system-specific device path that indicates which device is behind
+	this wp_tablet_pad. This information may be used to gather additional
+	information about the device, e.g. through libwacom.
+
+	The format of the path is unspecified, it may be a device node, a
+	sysfs path, or some other identifier. It is up to the client to
+	identify the string provided.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet_pad.done event.
+      </description>
+      <arg name="path" type="string" summary="path to local device"/>
+    </event>
+
+    <event name="buttons">
+      <description summary="buttons announced">
+	Sent on wp_tablet_pad initialization to announce the available
+	buttons.
+
+	This event is sent in the initial burst of events before the
+	wp_tablet_pad.done event. This event is only sent when at least one
+	button is available.
+      </description>
+      <arg name="buttons" type="uint" summary="the number of buttons"/>
+    </event>
+
+    <event name="done">
+      <description summary="pad description event sequence complete">
+	This event signals the end of the initial burst of descriptive
+	events. A client may consider the static description of the pad to
+	be complete and finalize initialization of the pad.
+      </description>
+    </event>
+
+    <enum name="button_state">
+      <description summary="physical button state">
+	Describes the physical state of a button that caused the button
+	event.
+      </description>
+      <entry name="released" value="0" summary="the button is not pressed"/>
+      <entry name="pressed" value="1" summary="the button is pressed"/>
+    </enum>
+
+    <event name="button">
+      <description summary="physical button state">
+	Sent whenever the physical state of a button changes.
+      </description>
+      <arg name="time" type="uint" summary="the time of the event with millisecond granularity"/>
+      <arg name="button" type="uint" summary="the index of the button that changed state"/>
+      <arg name="state" type="uint" enum="button_state"/>
+    </event>
+
+    <event name="enter">
+      <description summary="enter event">
+	Notification that this pad is focused on the specified surface.
+      </description>
+      <arg name="serial" type="uint" summary="serial number of the enter event"/>
+      <arg name="tablet" type="object" interface="zwp_tablet_v2" summary="the tablet the pad is attached to"/>
+      <arg name="surface" type="object" interface="wl_surface" summary="surface the pad is focused on"/>
+    </event>
+
+    <event name="leave">
+      <description summary="leave event">
+	Notification that this pad is no longer focused on the specified
+	surface.
+      </description>
+      <arg name="serial" type="uint" summary="serial number of the leave event"/>
+      <arg name="surface" type="object" interface="wl_surface" summary="surface the pad is no longer focused on"/>
+    </event>
+
+    <event name="removed">
+      <description summary="pad removed event">
+	Sent when the pad has been removed from the system. When a tablet
+	is removed its pad(s) will be removed too.
+
+	When this event is received, the client must destroy all rings, strips
+	and groups that were offered by this pad, and issue wp_tablet_pad.destroy
+	the pad itself.
+      </description>
+    </event>
+  </interface>
+
+  <interface name="zwp_tablet_pad_dial_v2" version="2">
+    <description summary="pad dial">
+      A rotary control, e.g. a dial or a wheel.
+
+      Events on a dial are logically grouped by the wl_tablet_pad_dial.frame
+      event.
+    </description>
+
+    <request name="set_feedback">
+      <description summary="set compositor feedback">
+	Requests the compositor to use the provided feedback string
+	associated with this dial. This request should be issued immediately
+	after a wp_tablet_pad_group.mode_switch event from the corresponding
+	group is received, or whenever the dial is mapped to a different
+	action. See wp_tablet_pad_group.mode_switch for more details.
+
+	Clients are encouraged to provide context-aware descriptions for
+	the actions associated with the dial, and compositors may use this
+	information to offer visual feedback about the button layout
+	(eg. on-screen displays).
+
+	The provided string 'description' is a UTF-8 encoded string to be
+	associated with this ring, and is considered user-visible; general
+	internationalization rules apply.
+
+	The serial argument will be that of the last
+	wp_tablet_pad_group.mode_switch event received for the group of this
+	dial. Requests providing other serials than the most recent one will be
+	ignored.
+      </description>
+      <arg name="description" type="string" summary="dial description"/>
+      <arg name="serial" type="uint" summary="serial of the mode switch event"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the dial object">
+	This destroys the client's resource for this dial object.
+      </description>
+    </request>
+
+    <event name="delta">
+      <description summary="delta movement">
+	Sent whenever the position on a dial changes.
+
+	This event carries the wheel delta as multiples or fractions
+	of 120 with each multiple of 120 representing one logical wheel detent.
+	For example, an axis_value120 of 30 is one quarter of
+	a logical wheel step in the positive direction, a value120 of
+	-240 are two logical wheel steps in the negative direction within the
+	same hardware event. See the wl_pointer.axis_value120 for more details.
+
+	The value120 must not be zero.
+      </description>
+      <arg name="value120" type="int" summary="rotation distance as fraction of 120"/>
+    </event>
+
+    <event name="frame">
+      <description summary="end of a dial event sequence">
+	Indicates the end of a set of events that represent one logical
+	hardware dial event. A client is expected to accumulate the data
+	in all events within the frame before proceeding.
+
+	All wp_tablet_pad_dial events before a wp_tablet_pad_dial.frame event belong
+	logically together.
+
+	A wp_tablet_pad_dial.frame event is sent for every logical event
+	group, even if the group only contains a single wp_tablet_pad_dial
+	event. Specifically, a client may get a sequence: delta, frame,
+	delta, frame, etc.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+    </event>
+  </interface>
+</protocol>

--- a/deps/wayland/xdg-toplevel-drag-v1.xml
+++ b/deps/wayland/xdg-toplevel-drag-v1.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="xdg_toplevel_drag_v1">
+
+  <copyright>
+    Copyright 2023 David Redondo
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="xdg_toplevel_drag_manager_v1" version="1">
+    <description summary="Move a window during a drag">
+      This protocol enhances normal drag and drop with the ability to move a
+      window at the same time. This allows having detachable parts of a window
+      that when dragged out of it become a new window and can be dragged over
+      an existing window to be reattached.
+
+      A typical workflow would be when the user starts dragging on top of a
+      detachable part of a window, the client would create a wl_data_source and
+      a xdg_toplevel_drag_v1 object and start the drag as normal via
+      wl_data_device.start_drag. Once the client determines that the detachable
+      window contents should be detached from the originating window, it creates
+      a new xdg_toplevel with these contents and issues a
+      xdg_toplevel_drag_v1.attach request before mapping it. From now on the new
+      window is moved by the compositor during the drag as if the client called
+      xdg_toplevel.move.
+
+      Dragging an existing window is similar. The client creates a
+      xdg_toplevel_drag_v1 object and attaches the existing toplevel before
+      starting the drag.
+
+      Clients use the existing drag and drop mechanism to detect when a window
+      can be docked or undocked. If the client wants to snap a window into a
+      parent window it should delete or unmap the dragged top-level. If the
+      contents should be detached again it attaches a new toplevel as described
+      above. If a drag operation is cancelled without being dropped, clients
+      should revert to the previous state, deleting any newly created windows
+      as appropriate. When a drag operation ends as indicated by
+      wl_data_source.dnd_drop_performed the dragged toplevel window's final
+      position is determined as if a xdg_toplevel_move operation ended.
+
+      Warning! The protocol described in this file is currently in the testing
+      phase. Backward compatible changes may be added together with the
+      corresponding interface version bump. Backward incompatible changes can
+      only be done by creating a new major version of the extension.
+    </description>
+
+    <enum name="error">
+      <entry name="invalid_source" value="0"
+             summary="data_source already used for toplevel drag"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the xdg_toplevel_drag_manager_v1 object">
+        Destroy this xdg_toplevel_drag_manager_v1 object. Other objects,
+        including xdg_toplevel_drag_v1 objects created by this factory, are not
+        affected by this request.
+      </description>
+    </request>
+
+    <request name="get_xdg_toplevel_drag">
+      <description summary="get an xdg_toplevel_drag for a wl_data_source">
+        Create an xdg_toplevel_drag for a drag and drop operation that is going
+        to be started with data_source.
+
+        This request can only be made on sources used in drag-and-drop, so it
+        must be performed before wl_data_device.start_drag. Attempting to use
+        the source other than for drag-and-drop such as in
+        wl_data_device.set_selection will raise an invalid_source error.
+
+        Destroying data_source while a toplevel is attached to the
+        xdg_toplevel_drag is undefined.
+      </description>
+
+      <arg name="id" type="new_id" interface="xdg_toplevel_drag_v1"/>
+      <arg name="data_source" type="object" interface="wl_data_source"/>
+    </request>
+  </interface>
+
+  <interface name="xdg_toplevel_drag_v1" version="1">
+    <description summary="Object representing a toplevel move during a drag">
+    </description>
+
+    <enum name="error">
+      <entry name="toplevel_attached" value="0"
+             summary="valid toplevel already attached"/>
+      <entry name="ongoing_drag" value="1"
+             summary="drag has not ended" />
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy an xdg_toplevel_drag_v1 object">
+        Destroy this xdg_toplevel_drag_v1 object. This request must only be
+        called after the underlying wl_data_source drag has ended, as indicated
+        by the dnd_drop_performed or cancelled events. In any other case an
+        ongoing_drag error is raised.
+      </description>
+    </request>
+
+    <request name="attach">
+      <description summary="Move a toplevel with the drag operation">
+        Request that the window will be moved with the cursor during the drag
+        operation. The offset is a hint to the compositor how the toplevel
+        should be positioned relative to the cursor hotspot in surface local
+        coordinates and relative to the geometry of the toplevel being attached.
+        See xdg_surface.set_window_geometry. For example it might only
+        be used when an unmapped window is attached. The attached window
+        does not participate in the selection of the drag target.
+
+        If the toplevel is unmapped while it is attached, it is automatically
+        detached from the drag. In this case this request has to be called again
+        if the window should be attached after it is remapped.
+
+        This request can be called multiple times but issuing it while a
+        toplevel with an active role is attached raises a toplevel_attached
+        error.
+      </description>
+
+      <arg name="toplevel" type="object" interface="xdg_toplevel"/>
+      <arg name="x_offset" type="int" summary="dragged surface x offset"/>
+      <arg name="y_offset" type="int" summary="dragged surface y offset"/>
+    </request>
+
+  </interface>
+</protocol>
+

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -3998,6 +3998,33 @@ GLFWAPI void glfwHideWindow(GLFWwindow* window);
  */
 GLFWAPI void glfwFocusWindow(GLFWwindow* window);
 
+/*! @brief Hand off an in-progress pointer drag to the window manager so it
+ *  moves this window until the user releases the pointer button.
+ *
+ *  This is the equivalent of the standard custom-titlebar drag pattern, but
+ *  initiated explicitly rather than from a titlebar hit test. It's primarily
+ *  useful when a window is created mid-drag (e.g. tearing out a docked tab
+ *  into a new viewport) and should seamlessly follow the cursor as if the
+ *  initial button press had been on this new window.
+ *
+ *  Requires a pointer button to currently be held. On Wayland this issues
+ *  xdg_toplevel.move (or libdecor_frame_move) using the latest user-event
+ *  serial. On Win32 it issues ReleaseCapture + WM_SYSCOMMAND SC_MOVE. On
+ *  X11 it sends a _NET_WM_MOVERESIZE ClientMessage. All of these use the
+ *  cursor's current location to anchor the drag, so no position needs to
+ *  be passed in.
+ *
+ *  @param[in] window The window to move.
+ *
+ *  @errors Possible errors include @ref GLFW_NOT_INITIALIZED and @ref
+ *  GLFW_PLATFORM_ERROR.
+ *
+ *  @thread_safety This function must only be called from the main thread.
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwDragWindow(GLFWwindow* window);
+
 /*! @brief Requests user attention to the specified window.
  *
  *  This function requests user attention to the specified window.  On

--- a/include/GLFW/glfw3.h
+++ b/include/GLFW/glfw3.h
@@ -3509,6 +3509,10 @@ GLFWAPI void glfwGetWindowPos(GLFWwindow* window, int* xpos, int* ypos);
  */
 GLFWAPI void glfwSetWindowPos(GLFWwindow* window, int xpos, int ypos);
 
+/*! @brief Sets the popup parent for xdg_popup nesting on Wayland.
+ */
+GLFWAPI void glfwSetPopupParent(GLFWwindow* window, GLFWwindow* parent);
+
 /*! @brief Retrieves the size of the content area of the specified window.
  *
  *  This function retrieves the size, in screen coordinates, of the content area

--- a/premake5.lua
+++ b/premake5.lua
@@ -66,6 +66,8 @@ project "GLFW"
 			"viewporter",
 			"wayland",
 			"xdg-activation-v1",
+			"cursor-shape-v1",
+			"tablet-v2",
 			"xdg-decoration-unstable-v1",
 			"xdg-shell"
 		}

--- a/premake5.lua
+++ b/premake5.lua
@@ -69,7 +69,8 @@ project "GLFW"
 			"cursor-shape-v1",
 			"tablet-v2",
 			"xdg-decoration-unstable-v1",
-			"xdg-shell"
+			"xdg-shell",
+			"xdg-toplevel-drag-v1"
 		}
 
 		for _, protocol in ipairs(protocols) do

--- a/premake5.lua
+++ b/premake5.lua
@@ -46,13 +46,43 @@ project "GLFW"
 			"src/glx_context.c",
 			"src/egl_context.c",
 			"src/osmesa_context.c",
-			"src/linux_joystick.c"
+			"src/linux_joystick.c",
+			"src/wl_init.c",
+			"src/wl_monitor.c",
+			"src/wl_window.c"
 		}
 
 		defines
 		{
-			"_GLFW_X11"
+			"_GLFW_X11",
+			"_GLFW_WAYLAND"
 		}
+
+		local protocols = {
+			"fractional-scale-v1",
+			"idle-inhibit-unstable-v1",
+			"pointer-constraints-unstable-v1",
+			"relative-pointer-unstable-v1",
+			"viewporter",
+			"wayland",
+			"xdg-activation-v1",
+			"xdg-decoration-unstable-v1",
+			"xdg-shell"
+		}
+
+		for _, protocol in ipairs(protocols) do
+			local out_file = "src/" .. protocol .. "-client-protocol.h"
+			local out_code_file = "src/" .. protocol .. "-client-protocol-code.h"
+
+			prebuildcommands {
+				"wayland-scanner client-header deps/wayland/" .. protocol .. ".xml " .. out_file,
+				"wayland-scanner private-code deps/wayland/" .. protocol .. ".xml " .. out_code_file
+			}
+
+			buildoutputs {
+				out_file
+			}
+		end
 
 	filter "system:macosx"
 		pic "On"

--- a/premake5.lua
+++ b/premake5.lua
@@ -70,7 +70,8 @@ project "GLFW"
 			"tablet-v2",
 			"xdg-decoration-unstable-v1",
 			"xdg-shell",
-			"xdg-toplevel-drag-v1"
+			"xdg-toplevel-drag-v1",
+			"kde-shadow"
 		}
 
 		for _, protocol in ipairs(protocols) do

--- a/premake5.lua
+++ b/premake5.lua
@@ -75,12 +75,14 @@ project "GLFW"
 		}
 
 		for _, protocol in ipairs(protocols) do
+			local xml_file = "deps/wayland/" .. protocol .. ".xml"
 			local out_file = "src/" .. protocol .. "-client-protocol.h"
 			local out_code_file = "src/" .. protocol .. "-client-protocol-code.h"
 
+			-- Only regenerate when the .xml source is newer than the output
 			prebuildcommands {
-				"wayland-scanner client-header deps/wayland/" .. protocol .. ".xml " .. out_file,
-				"wayland-scanner private-code deps/wayland/" .. protocol .. ".xml " .. out_code_file
+				"@test " .. out_file .. " -nt " .. xml_file .. " || wayland-scanner client-header " .. xml_file .. " " .. out_file,
+				"@test " .. out_code_file .. " -nt " .. xml_file .. " || wayland-scanner private-code " .. xml_file .. " " .. out_code_file
 			}
 
 			buildoutputs {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -105,6 +105,7 @@ if (GLFW_BUILD_WAYLAND)
     generate_wayland_protocol("fractional-scale-v1.xml")
     generate_wayland_protocol("xdg-activation-v1.xml")
     generate_wayland_protocol("xdg-decoration-unstable-v1.xml")
+    generate_wayland_protocol("xdg-toplevel-drag-v1.xml")
 endif()
 
 if (WIN32 AND GLFW_BUILD_SHARED_LIBRARY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,6 +106,8 @@ if (GLFW_BUILD_WAYLAND)
     generate_wayland_protocol("xdg-activation-v1.xml")
     generate_wayland_protocol("xdg-decoration-unstable-v1.xml")
     generate_wayland_protocol("xdg-toplevel-drag-v1.xml")
+    generate_wayland_protocol("cursor-shape-v1.xml")
+    generate_wayland_protocol("tablet-v2.xml")
 endif()
 
 if (WIN32 AND GLFW_BUILD_SHARED_LIBRARY)

--- a/src/cocoa_init.m
+++ b/src/cocoa_init.m
@@ -507,6 +507,7 @@ GLFWbool _glfwConnectCocoa(int platformID, _GLFWplatform* platform)
         .hideWindow = _glfwHideWindowCocoa,
         .requestWindowAttention = _glfwRequestWindowAttentionCocoa,
         .focusWindow = _glfwFocusWindowCocoa,
+        .dragWindow = _glfwDragWindowCocoa,
         .setWindowMonitor = _glfwSetWindowMonitorCocoa,
         .windowFocused = _glfwWindowFocusedCocoa,
         .windowIconified = _glfwWindowIconifiedCocoa,

--- a/src/cocoa_platform.h
+++ b/src/cocoa_platform.h
@@ -234,6 +234,7 @@ void _glfwShowWindowCocoa(_GLFWwindow* window);
 void _glfwHideWindowCocoa(_GLFWwindow* window);
 void _glfwRequestWindowAttentionCocoa(_GLFWwindow* window);
 void _glfwFocusWindowCocoa(_GLFWwindow* window);
+void _glfwDragWindowCocoa(_GLFWwindow* window);
 void _glfwSetWindowMonitorCocoa(_GLFWwindow* window, _GLFWmonitor* monitor, int xpos, int ypos, int width, int height, int refreshRate);
 GLFWbool _glfwWindowFocusedCocoa(_GLFWwindow* window);
 GLFWbool _glfwWindowIconifiedCocoa(_GLFWwindow* window);

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -1240,6 +1240,22 @@ void _glfwFocusWindowCocoa(_GLFWwindow* window)
     } // autoreleasepool
 }
 
+void _glfwDragWindowCocoa(_GLFWwindow* window)
+{
+    @autoreleasepool {
+    // -[NSWindow performWindowDragWithEvent:] requires a currently-dispatching
+    // mouse-down NSEvent. We don't have easy access to the original event here,
+    // so fall back to the closest available current event. If there isn't a
+    // live drag event, this is a no-op — matching Wayland's "no serial" gate.
+    NSEvent* event = [NSApp currentEvent];
+    if (event && ([event type] == NSEventTypeLeftMouseDown ||
+                  [event type] == NSEventTypeLeftMouseDragged))
+    {
+        [window->ns.object performWindowDragWithEvent:event];
+    }
+    } // autoreleasepool
+}
+
 void _glfwSetWindowMonitorCocoa(_GLFWwindow* window,
                                 _GLFWmonitor* monitor,
                                 int xpos, int ypos,

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -417,6 +417,13 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
         const NSPoint pos = [event locationInWindow];
         const int x = (int)pos.x;
         const int y = (int)(contentRect.size.height - pos.y);
+        // Skip native drag near window edges to allow resize
+        const int border = 5;
+        const int w = (int)contentRect.size.width;
+        const int h = (int)contentRect.size.height;
+        if (x < border || x > w - border || y < border || y > h - border)
+            return;
+
         int hit = 0;
         window->callbacks.tbhittest((GLFWwindow*)window, x, y, &hit);
         if (hit)

--- a/src/cocoa_window.m
+++ b/src/cocoa_window.m
@@ -408,6 +408,23 @@ static const NSRange kEmptyRange = { NSNotFound, 0 };
                          GLFW_MOUSE_BUTTON_LEFT,
                          GLFW_PRESS,
                          translateFlags([event modifierFlags]));
+
+    // If the app's titlebar hit test says we're in the drag zone,
+    // hand off to the native window drag (no jitter).
+    if (window->callbacks.tbhittest)
+    {
+        const NSRect contentRect = [window->ns.view frame];
+        const NSPoint pos = [event locationInWindow];
+        const int x = (int)pos.x;
+        const int y = (int)(contentRect.size.height - pos.y);
+        int hit = 0;
+        window->callbacks.tbhittest((GLFWwindow*)window, x, y, &hit);
+        if (hit)
+        {
+            [window->ns.object performWindowDragWithEvent:event];
+            return;
+        }
+    }
 }
 
 - (void)mouseDragged:(NSEvent *)event

--- a/src/input.c
+++ b/src/input.c
@@ -828,13 +828,14 @@ GLFWAPI void glfwSetCursorPos(GLFWwindow* handle, double xpos, double ypos)
 
     if (window->cursorMode == GLFW_CURSOR_DISABLED)
     {
-        // Only update the accumulated position if the cursor is disabled
         window->virtualCursorPosX = xpos;
         window->virtualCursorPosY = ypos;
+        // Also forward to the platform so Wayland can latch a
+        // set_cursor_position_hint before the lock is destroyed.
+        _glfw.platform.setCursorPos(window, xpos, ypos);
     }
     else
     {
-        // Update system cursor position
         _glfw.platform.setCursorPos(window, xpos, ypos);
     }
 }

--- a/src/internal.h
+++ b/src/internal.h
@@ -737,6 +737,7 @@ struct _GLFWplatform
     void (*hideWindow)(_GLFWwindow*);
     void (*requestWindowAttention)(_GLFWwindow*);
     void (*focusWindow)(_GLFWwindow*);
+    void (*dragWindow)(_GLFWwindow*);
     void (*setWindowMonitor)(_GLFWwindow*,_GLFWmonitor*,int,int,int,int,int);
     GLFWbool (*windowFocused)(_GLFWwindow*);
     GLFWbool (*windowIconified)(_GLFWwindow*);

--- a/src/internal.h
+++ b/src/internal.h
@@ -542,6 +542,8 @@ struct _GLFWwindow
     GLFWbool            mousePassthrough;
     GLFWbool            shouldClose;
     void*               userPointer;
+    // Explicit popup parent for proper xdg_popup nesting on Wayland.
+    struct _GLFWwindow* popupParent;
     GLFWbool            doublebuffer;
     GLFWvidmode         videoMode;
     _GLFWmonitor*       monitor;

--- a/src/null_init.c
+++ b/src/null_init.c
@@ -88,6 +88,7 @@ GLFWbool _glfwConnectNull(int platformID, _GLFWplatform* platform)
         .hideWindow = _glfwHideWindowNull,
         .requestWindowAttention = _glfwRequestWindowAttentionNull,
         .focusWindow = _glfwFocusWindowNull,
+        .dragWindow = _glfwDragWindowNull,
         .setWindowMonitor = _glfwSetWindowMonitorNull,
         .windowFocused = _glfwWindowFocusedNull,
         .windowIconified = _glfwWindowIconifiedNull,

--- a/src/null_platform.h
+++ b/src/null_platform.h
@@ -252,6 +252,7 @@ void _glfwShowWindowNull(_GLFWwindow* window);
 void _glfwRequestWindowAttentionNull(_GLFWwindow* window);
 void _glfwHideWindowNull(_GLFWwindow* window);
 void _glfwFocusWindowNull(_GLFWwindow* window);
+void _glfwDragWindowNull(_GLFWwindow* window);
 GLFWbool _glfwWindowFocusedNull(_GLFWwindow* window);
 GLFWbool _glfwWindowIconifiedNull(_GLFWwindow* window);
 GLFWbool _glfwWindowVisibleNull(_GLFWwindow* window);

--- a/src/null_window.c
+++ b/src/null_window.c
@@ -474,6 +474,11 @@ void _glfwFocusWindowNull(_GLFWwindow* window)
     _glfwInputWindowFocus(window, GLFW_TRUE);
 }
 
+void _glfwDragWindowNull(_GLFWwindow* window)
+{
+    // No windowing system to hand the drag off to.
+}
+
 GLFWbool _glfwWindowFocusedNull(_GLFWwindow* window)
 {
     return _glfw.null.focusedWindow == window;

--- a/src/win32_init.c
+++ b/src/win32_init.c
@@ -625,6 +625,7 @@ GLFWbool _glfwConnectWin32(int platformID, _GLFWplatform* platform)
         .hideWindow = _glfwHideWindowWin32,
         .requestWindowAttention = _glfwRequestWindowAttentionWin32,
         .focusWindow = _glfwFocusWindowWin32,
+        .dragWindow = _glfwDragWindowWin32,
         .setWindowMonitor = _glfwSetWindowMonitorWin32,
         .windowFocused = _glfwWindowFocusedWin32,
         .windowIconified = _glfwWindowIconifiedWin32,

--- a/src/win32_platform.h
+++ b/src/win32_platform.h
@@ -502,6 +502,7 @@ void _glfwShowWindowWin32(_GLFWwindow* window);
 void _glfwHideWindowWin32(_GLFWwindow* window);
 void _glfwRequestWindowAttentionWin32(_GLFWwindow* window);
 void _glfwFocusWindowWin32(_GLFWwindow* window);
+void _glfwDragWindowWin32(_GLFWwindow* window);
 void _glfwSetWindowMonitorWin32(_GLFWwindow* window, _GLFWmonitor* monitor, int xpos, int ypos, int width, int height, int refreshRate);
 GLFWbool _glfwWindowFocusedWin32(_GLFWwindow* window);
 GLFWbool _glfwWindowIconifiedWin32(_GLFWwindow* window);

--- a/src/win32_platform.h
+++ b/src/win32_platform.h
@@ -375,6 +375,8 @@ typedef struct _GLFWwindowWin32
     int                 lastCursorPosX, lastCursorPosY;
     // The last received high surrogate when decoding pairs of UTF-16 messages
     WCHAR               highSurrogate;
+    // Last WM_NCHITTEST result, or 0 if never hit-tested.
+    int                 lastHitTest;
 } _GLFWwindowWin32;
 
 // Win32-specific global data

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -1974,12 +1974,26 @@ void _glfwFocusWindowWin32(_GLFWwindow* window)
 
 void _glfwDragWindowWin32(_GLFWwindow* window)
 {
-    // Hand the in-progress pointer drag off to the window manager. Windows
-    // uses the cursor's current location to anchor the move, same as
-    // xdg_toplevel.move on Wayland. Standard pattern for custom titlebar
-    // drag (Chrome, Electron, anything with a non-native caption).
-    ReleaseCapture();
-    SendMessageW(window->win32.handle, WM_SYSCOMMAND, SC_MOVE | HTCAPTION, 0);
+    // No-op on Win32. Mirrors the X11 behaviour: rely on Windows' implicit
+    // mouse capture (WM_LBUTTONDOWN captures subsequent motion/release events
+    // for the originating window until release) so the caller can drive a
+    // drag via glfwSetWindowPos each frame and still receive the mouse-up
+    // event at the end.
+    //
+    // The earlier SC_MOVE + HTCAPTION implementation worked for the simple
+    // case but has two defects: DefWindowProc's SC_MOVE modal loop consumes
+    // the WM_LBUTTONUP rather than forwarding it, so GLFW (and callers such
+    // as ImGui multi-viewport) never see the release — they stay stuck in
+    // drag state; and SendMessageW blocks until the modal loop returns,
+    // which on the GLFW fork used by LuckyEngine means the render thread
+    // holds a cross-thread send on the main thread for the duration of the
+    // user's drag.
+    //
+    // Callers that want classic WM-driven move behaviour can use the
+    // titlebar hit-test callback (glfwSetTitlebarHitTestCallback) — that
+    // path returns HTCAPTION from WM_NCHITTEST and Windows handles the
+    // drag directly without involving SendMessage.
+    (void)window;
 }
 
 void _glfwSetWindowMonitorWin32(_GLFWwindow* window,

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -1974,25 +1974,9 @@ void _glfwFocusWindowWin32(_GLFWwindow* window)
 
 void _glfwDragWindowWin32(_GLFWwindow* window)
 {
-    // No-op on Win32. Mirrors the X11 behaviour: rely on Windows' implicit
-    // mouse capture (WM_LBUTTONDOWN captures subsequent motion/release events
-    // for the originating window until release) so the caller can drive a
-    // drag via glfwSetWindowPos each frame and still receive the mouse-up
-    // event at the end.
-    //
-    // The earlier SC_MOVE + HTCAPTION implementation worked for the simple
-    // case but has two defects: DefWindowProc's SC_MOVE modal loop consumes
-    // the WM_LBUTTONUP rather than forwarding it, so GLFW (and callers such
-    // as ImGui multi-viewport) never see the release — they stay stuck in
-    // drag state; and SendMessageW blocks until the modal loop returns,
-    // which on the GLFW fork used by LuckyEngine means the render thread
-    // holds a cross-thread send on the main thread for the duration of the
-    // user's drag.
-    //
-    // Callers that want classic WM-driven move behaviour can use the
-    // titlebar hit-test callback (glfwSetTitlebarHitTestCallback) — that
-    // path returns HTCAPTION from WM_NCHITTEST and Windows handles the
-    // drag directly without involving SendMessage.
+    // No-op: Win32's implicit mouse capture lets callers drive the drag
+    // via glfwSetWindowPos. SC_MOVE's modal loop swallows WM_LBUTTONUP,
+    // which breaks callers that need to see the release (e.g. ImGui).
     (void)window;
 }
 

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -1972,6 +1972,16 @@ void _glfwFocusWindowWin32(_GLFWwindow* window)
     SetFocus(window->win32.handle);
 }
 
+void _glfwDragWindowWin32(_GLFWwindow* window)
+{
+    // Hand the in-progress pointer drag off to the window manager. Windows
+    // uses the cursor's current location to anchor the move, same as
+    // xdg_toplevel.move on Wayland. Standard pattern for custom titlebar
+    // drag (Chrome, Electron, anything with a non-native caption).
+    ReleaseCapture();
+    SendMessageW(window->win32.handle, WM_SYSCOMMAND, SC_MOVE | HTCAPTION, 0);
+}
+
 void _glfwSetWindowMonitorWin32(_GLFWwindow* window,
                                 _GLFWmonitor* monitor,
                                 int xpos, int ypos,

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -1373,6 +1373,8 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
             POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
             ScreenToClient(hWnd, &pt);
 
+            int result = HTCLIENT;
+
             // Check borders first
             if (!window->win32.maximized)
             {
@@ -1392,24 +1394,27 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
                 if (pt.y >= rc.bottom - border_thickness.bottom)
                     hit |= bottom;
 
-                if (hit & top && hit & left)        return HTTOPLEFT;
-                if (hit & top && hit & right)       return HTTOPRIGHT;
-                if (hit & bottom && hit & left)     return HTBOTTOMLEFT;
-                if (hit & bottom && hit & right)    return HTBOTTOMRIGHT;
-                if (hit & left)                     return HTLEFT;
-                if (hit & top)                      return HTTOP;
-                if (hit & right)                    return HTRIGHT;
-                if (hit & bottom)                   return HTBOTTOM;
+                if      (hit & top && hit & left)    result = HTTOPLEFT;
+                else if (hit & top && hit & right)   result = HTTOPRIGHT;
+                else if (hit & bottom && hit & left) result = HTBOTTOMLEFT;
+                else if (hit & bottom && hit & right)result = HTBOTTOMRIGHT;
+                else if (hit & left)                 result = HTLEFT;
+                else if (hit & top)                  result = HTTOP;
+                else if (hit & right)                result = HTRIGHT;
+                else if (hit & bottom)               result = HTBOTTOM;
             }
 
-            // Then do client-side test which should determine titlebar bounds
-            int titlebarHittest = 0;
-            _glfwInputTitleBarHitTest(window, pt.x, pt.y, &titlebarHittest);
-            if (titlebarHittest)
-                return HTCAPTION;
+            if (result == HTCLIENT)
+            {
+                // Then do client-side test which should determine titlebar bounds
+                int titlebarHittest = 0;
+                _glfwInputTitleBarHitTest(window, pt.x, pt.y, &titlebarHittest);
+                if (titlebarHittest)
+                    result = HTCAPTION;
+            }
 
-            // In client area
-            return HTCLIENT;
+            window->win32.lastHitTest = result;
+            return result;
         }
     }
 
@@ -2509,6 +2514,10 @@ void _glfwDestroyCursorWin32(_GLFWcursor* cursor)
 
 void _glfwSetCursorWin32(_GLFWwindow* window, _GLFWcursor* cursor)
 {
+    // Don't override the OS resize cursor on the border.
+    if (window->win32.lastHitTest != 0 && window->win32.lastHitTest != HTCLIENT)
+        return;
+
     if (cursorInContentArea(window))
         updateCursorImage(window);
 }

--- a/src/win32_window.c
+++ b/src/win32_window.c
@@ -1094,7 +1094,12 @@ static LRESULT CALLBACK windowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
             // mouse icon change to a resize handle, but resizing still
             // works once you click and drag. This works on both
             // Windows 10 & 11, so we'll keep that for now.
-            requestedClientRect->top += 0;
+            //
+            // When maximized, Windows pads the proposed window rect by
+            // resizeBorderY on top so the resize cursor is reachable past
+            // the monitor edge. Undo that pad so the client area sits flush
+            // with the monitor top instead of bleeding off-screen.
+            requestedClientRect->top += IsZoomed(hWnd) ? resizeBorderY : 0;
 
             // NOTE(Yan): seems to make no difference what we return here,
             //            was originally 0

--- a/src/window.c
+++ b/src/window.c
@@ -888,6 +888,17 @@ GLFWAPI void glfwFocusWindow(GLFWwindow* handle)
     _glfw.platform.focusWindow(window);
 }
 
+GLFWAPI void glfwDragWindow(GLFWwindow* handle)
+{
+    _GLFW_REQUIRE_INIT();
+
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    assert(window != NULL);
+
+    if (_glfw.platform.dragWindow)
+        _glfw.platform.dragWindow(window);
+}
+
 GLFWAPI int glfwGetWindowAttrib(GLFWwindow* handle, int attrib)
 {
     _GLFW_REQUIRE_INIT_OR_RETURN(0);

--- a/src/window.c
+++ b/src/window.c
@@ -618,6 +618,14 @@ GLFWAPI void glfwSetWindowPos(GLFWwindow* handle, int xpos, int ypos)
     _glfw.platform.setWindowPos(window, xpos, ypos);
 }
 
+GLFWAPI void glfwSetPopupParent(GLFWwindow* handle, GLFWwindow* parentHandle)
+{
+    _GLFW_REQUIRE_INIT();
+    _GLFWwindow* window = (_GLFWwindow*) handle;
+    assert(window != NULL);
+    window->popupParent = parentHandle ? (_GLFWwindow*) parentHandle : NULL;
+}
+
 GLFWAPI void glfwGetWindowSize(GLFWwindow* handle, int* width, int* height)
 {
     if (width)

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -47,6 +47,8 @@
 #include "relative-pointer-unstable-v1-client-protocol.h"
 #include "pointer-constraints-unstable-v1-client-protocol.h"
 #include "fractional-scale-v1-client-protocol.h"
+#include "cursor-shape-v1-client-protocol.h"
+#include "tablet-v2-client-protocol.h"
 #include "xdg-activation-v1-client-protocol.h"
 #include "idle-inhibit-unstable-v1-client-protocol.h"
 
@@ -81,6 +83,14 @@
 
 #define types _glfw_fractional_scale_types
 #include "fractional-scale-v1-client-protocol-code.h"
+#undef types
+
+#define types _glfw_tablet_v2_types
+#include "tablet-v2-client-protocol-code.h"
+#undef types
+
+#define types _glfw_cursor_shape_types
+#include "cursor-shape-v1-client-protocol-code.h"
 #undef types
 
 #define types _glfw_xdg_activation_types
@@ -199,6 +209,13 @@ static void registryHandleGlobal(void* userData,
         _glfw.wl.fractionalScaleManager =
             wl_registry_bind(registry, name,
                              &wp_fractional_scale_manager_v1_interface,
+                             1);
+    }
+    else if (strcmp(interface, "wp_cursor_shape_manager_v1") == 0)
+    {
+        _glfw.wl.cursorShapeManager =
+            wl_registry_bind(registry, name,
+                             &wp_cursor_shape_manager_v1_interface,
                              1);
     }
 }
@@ -991,6 +1008,8 @@ void _glfwTerminateWayland(void)
         xdg_activation_v1_destroy(_glfw.wl.activationManager);
     if (_glfw.wl.fractionalScaleManager)
         wp_fractional_scale_manager_v1_destroy(_glfw.wl.fractionalScaleManager);
+    if (_glfw.wl.cursorShapeManager)
+        wp_cursor_shape_manager_v1_destroy(_glfw.wl.cursorShapeManager);
     if (_glfw.wl.registry)
         wl_registry_destroy(_glfw.wl.registry);
     if (_glfw.wl.display)

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -51,6 +51,7 @@
 #include "tablet-v2-client-protocol.h"
 #include "xdg-activation-v1-client-protocol.h"
 #include "idle-inhibit-unstable-v1-client-protocol.h"
+#include "xdg-toplevel-drag-v1-client-protocol.h"
 
 // NOTE: Versions of wayland-scanner prior to 1.17.91 named every global array of
 //       wl_interface pointers 'types', making it impossible to combine several unmodified
@@ -99,6 +100,10 @@
 
 #define types _glfw_idle_inhibit_types
 #include "idle-inhibit-unstable-v1-client-protocol-code.h"
+#undef types
+
+#define types _glfw_xdg_toplevel_drag_types
+#include "xdg-toplevel-drag-v1-client-protocol-code.h"
 #undef types
 
 static void wmBaseHandlePing(void* userData,
@@ -153,9 +158,16 @@ static void registryHandleGlobal(void* userData,
     {
         if (!_glfw.wl.dataDeviceManager)
         {
+            // Bind at version 3 when the compositor supports it — this is
+            // what enables wl_data_offer_set_actions / .finish and
+            // wl_data_source.dnd_drop_performed / .dnd_finished, all of
+            // which we rely on to complete a self-initiated toplevel drag
+            // cleanly. Fall back to lower versions transparently.
+            const uint32_t bindVersion = version >= 3 ? 3 : version;
             _glfw.wl.dataDeviceManager =
                 wl_registry_bind(registry, name,
-                                 &wl_data_device_manager_interface, 1);
+                                 &wl_data_device_manager_interface,
+                                 bindVersion);
         }
     }
     else if (strcmp(interface, "xdg_wm_base") == 0)
@@ -202,6 +214,13 @@ static void registryHandleGlobal(void* userData,
         _glfw.wl.activationManager =
             wl_registry_bind(registry, name,
                              &xdg_activation_v1_interface,
+                             1);
+    }
+    else if (strcmp(interface, "xdg_toplevel_drag_manager_v1") == 0)
+    {
+        _glfw.wl.toplevelDragManager =
+            wl_registry_bind(registry, name,
+                             &xdg_toplevel_drag_manager_v1_interface,
                              1);
     }
     else if (strcmp(interface, "wp_fractional_scale_manager_v1") == 0)
@@ -1012,6 +1031,8 @@ void _glfwTerminateWayland(void)
         zwp_idle_inhibit_manager_v1_destroy(_glfw.wl.idleInhibitManager);
     if (_glfw.wl.activationManager)
         xdg_activation_v1_destroy(_glfw.wl.activationManager);
+    if (_glfw.wl.toplevelDragManager)
+        xdg_toplevel_drag_manager_v1_destroy(_glfw.wl.toplevelDragManager);
     if (_glfw.wl.fractionalScaleManager)
         wp_fractional_scale_manager_v1_destroy(_glfw.wl.fractionalScaleManager);
     if (_glfw.wl.cursorShapeManager)

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -52,6 +52,7 @@
 #include "xdg-activation-v1-client-protocol.h"
 #include "idle-inhibit-unstable-v1-client-protocol.h"
 #include "xdg-toplevel-drag-v1-client-protocol.h"
+#include "kde-shadow-client-protocol.h"
 
 // NOTE: Versions of wayland-scanner prior to 1.17.91 named every global array of
 //       wl_interface pointers 'types', making it impossible to combine several unmodified
@@ -104,6 +105,10 @@
 
 #define types _glfw_xdg_toplevel_drag_types
 #include "xdg-toplevel-drag-v1-client-protocol-code.h"
+#undef types
+
+#define types _glfw_kde_shadow_types
+#include "kde-shadow-client-protocol-code.h"
 #undef types
 
 static void wmBaseHandlePing(void* userData,
@@ -233,6 +238,13 @@ static void registryHandleGlobal(void* userData,
             wl_registry_bind(registry, name,
                              &wp_cursor_shape_manager_v1_interface,
                              1);
+    }
+    else if (strcmp(interface, "org_kde_kwin_shadow_manager") == 0)
+    {
+        _glfw.wl.shadowManager =
+            wl_registry_bind(registry, name,
+                             &org_kde_kwin_shadow_manager_interface,
+                             _glfw_min(version, 2));
     }
 }
 
@@ -998,6 +1010,13 @@ void _glfwTerminateWayland(void)
         wl_shm_destroy(_glfw.wl.shm);
     if (_glfw.wl.viewporter)
         wp_viewporter_destroy(_glfw.wl.viewporter);
+    if (_glfw.wl.shadowManager)
+    {
+        if (wl_proxy_get_version((struct wl_proxy*) _glfw.wl.shadowManager) >= ORG_KDE_KWIN_SHADOW_MANAGER_DESTROY_SINCE_VERSION)
+            org_kde_kwin_shadow_manager_destroy(_glfw.wl.shadowManager);
+        else
+            wl_proxy_destroy((struct wl_proxy*) _glfw.wl.shadowManager);
+    }
     if (_glfw.wl.decorationManager)
         zxdg_decoration_manager_v1_destroy(_glfw.wl.decorationManager);
     if (_glfw.wl.wmBase)

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -158,11 +158,8 @@ static void registryHandleGlobal(void* userData,
     {
         if (!_glfw.wl.dataDeviceManager)
         {
-            // Bind at version 3 when the compositor supports it — this is
-            // what enables wl_data_offer_set_actions / .finish and
-            // wl_data_source.dnd_drop_performed / .dnd_finished, all of
-            // which we rely on to complete a self-initiated toplevel drag
-            // cleanly. Fall back to lower versions transparently.
+            // v3 adds set_actions/finish/dnd_drop_performed/dnd_finished,
+            // needed for clean toplevel drag completion.
             const uint32_t bindVersion = version >= 3 ? 3 : version;
             _glfw.wl.dataDeviceManager =
                 wl_registry_bind(registry, name,
@@ -841,9 +838,7 @@ int _glfwInitWayland(void)
             _glfwPlatformGetModuleSymbol(_glfw.wl.libdecor.handle, "libdecor_frame_set_visibility");
         _glfw.wl.libdecor.libdecor_frame_get_xdg_toplevel_ = (PFN_libdecor_frame_get_xdg_toplevel)
             _glfwPlatformGetModuleSymbol(_glfw.wl.libdecor.handle, "libdecor_frame_get_xdg_toplevel");
-        // Optional: only present in libdecor 0.2+. Not in the required-set below
-        // (its absence doesn't prevent libdecor from working for toplevels), but
-        // when present it lets xdg_popup windows be parented to libdecor frames.
+        // Optional (libdecor 0.2+): lets xdg_popup parent to libdecor frames.
         _glfw.wl.libdecor.libdecor_frame_get_xdg_surface_ = (PFN_libdecor_frame_get_xdg_surface)
             _glfwPlatformGetModuleSymbol(_glfw.wl.libdecor.handle, "libdecor_frame_get_xdg_surface");
         _glfw.wl.libdecor.libdecor_configuration_get_content_size_ = (PFN_libdecor_configuration_get_content_size)

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -821,6 +821,11 @@ int _glfwInitWayland(void)
             _glfwPlatformGetModuleSymbol(_glfw.wl.libdecor.handle, "libdecor_frame_set_visibility");
         _glfw.wl.libdecor.libdecor_frame_get_xdg_toplevel_ = (PFN_libdecor_frame_get_xdg_toplevel)
             _glfwPlatformGetModuleSymbol(_glfw.wl.libdecor.handle, "libdecor_frame_get_xdg_toplevel");
+        // Optional: only present in libdecor 0.2+. Not in the required-set below
+        // (its absence doesn't prevent libdecor from working for toplevels), but
+        // when present it lets xdg_popup windows be parented to libdecor frames.
+        _glfw.wl.libdecor.libdecor_frame_get_xdg_surface_ = (PFN_libdecor_frame_get_xdg_surface)
+            _glfwPlatformGetModuleSymbol(_glfw.wl.libdecor.handle, "libdecor_frame_get_xdg_surface");
         _glfw.wl.libdecor.libdecor_configuration_get_content_size_ = (PFN_libdecor_configuration_get_content_size)
             _glfwPlatformGetModuleSymbol(_glfw.wl.libdecor.handle, "libdecor_configuration_get_content_size");
         _glfw.wl.libdecor.libdecor_configuration_get_window_state_ = (PFN_libdecor_configuration_get_window_state)

--- a/src/wl_init.c
+++ b/src/wl_init.c
@@ -503,6 +503,7 @@ GLFWbool _glfwConnectWayland(int platformID, _GLFWplatform* platform)
         .hideWindow = _glfwHideWindowWayland,
         .requestWindowAttention = _glfwRequestWindowAttentionWayland,
         .focusWindow = _glfwFocusWindowWayland,
+        .dragWindow = _glfwDragWindowWayland,
         .setWindowMonitor = _glfwSetWindowMonitorWayland,
         .windowFocused = _glfwWindowFocusedWayland,
         .windowIconified = _glfwWindowIconifiedWayland,

--- a/src/wl_monitor.c
+++ b/src/wl_monitor.c
@@ -207,10 +207,16 @@ void _glfwGetMonitorPosWayland(_GLFWmonitor* monitor, int* xpos, int* ypos)
 void _glfwGetMonitorContentScaleWayland(_GLFWmonitor* monitor,
                                         float* xscale, float* yscale)
 {
+    float scale;
+    if (monitor->wl.fractionalScaleNumerator)
+        scale = (float) monitor->wl.fractionalScaleNumerator / 120.f;
+    else
+        scale = (float) monitor->wl.scale;
+
     if (xscale)
-        *xscale = (float) monitor->wl.scale;
+        *xscale = scale;
     if (yscale)
-        *yscale = (float) monitor->wl.scale;
+        *yscale = scale;
 }
 
 void _glfwGetMonitorWorkareaWayland(_GLFWmonitor* monitor,

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -356,6 +356,12 @@ typedef struct _GLFWofferWayland
     struct wl_data_offer*       offer;
     GLFWbool                    text_plain_utf8;
     GLFWbool                    text_uri_list;
+    // Marker for our self-initiated toplevel drag (see glfwDragWindow on
+    // Wayland). Whenever we see an offer advertising this mime type we
+    // accept it so the compositor delivers motion events to us — which lets
+    // ImGui detect dock targets while the dragged toplevel is following
+    // the cursor via xdg_toplevel_drag_v1.
+    GLFWbool                    glfw_window_drag;
 } _GLFWofferWayland;
 
 typedef struct _GLFWscaleWayland
@@ -479,6 +485,7 @@ typedef struct _GLFWlibraryWayland
     struct zwp_pointer_constraints_v1*      pointerConstraints;
     struct zwp_idle_inhibit_manager_v1*     idleInhibitManager;
     struct xdg_activation_v1*               activationManager;
+    struct xdg_toplevel_drag_manager_v1*    toplevelDragManager;
     struct wp_fractional_scale_manager_v1*  fractionalScaleManager;
     struct wp_cursor_shape_manager_v1*      cursorShapeManager;
     struct wp_cursor_shape_device_v1*       cursorShapeDevice;
@@ -492,6 +499,18 @@ typedef struct _GLFWlibraryWayland
     struct wl_data_offer*       dragOffer;
     _GLFWwindow*                dragFocus;
     uint32_t                    dragSerial;
+
+    // Self-initiated window-drag session via xdg_toplevel_drag_v1. Set up by
+    // _glfwDragWindowWayland when the manager global is available. While the
+    // session is active, DnD motion events over this client's surfaces are
+    // converted into cursor-move events so ImGui (or any app) can detect
+    // drop targets (dock bars, etc.) even though pointer input is captured
+    // by the drag.
+    struct {
+        struct wl_data_source*          source;
+        struct xdg_toplevel_drag_v1*    drag;
+        _GLFWwindow*                    window;
+    } toplevelDragSession;
 
     const char*                 tag;
 
@@ -508,6 +527,11 @@ typedef struct _GLFWlibraryWayland
     // keyboard), which is invalid for those requests and can crash strict
     // compositors (KWin has been observed to crash).
     uint32_t                    pointerButtonSerial;
+    // Surface that received the press associated with pointerButtonSerial.
+    // Used as the `origin` for wl_data_device.start_drag — the compositor
+    // rejects (silently) any drag whose origin doesn't match the pressed
+    // surface tied to the serial.
+    struct wl_surface*          pointerButtonSurface;
     // Count of currently-held pointer buttons. Deferred drag-moves only fire
     // while this is non-zero; otherwise the press serial is stale and passing
     // it to xdg_toplevel.move is undefined per spec.

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -371,6 +371,7 @@ typedef struct _GLFWscaleWayland
 typedef struct _GLFWwindowWayland
 {
     int                         width, height;
+    int                         floatingWidth, floatingHeight;
     int                         fbWidth, fbHeight;
     GLFWbool                    visible;
     GLFWbool                    maximized;

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -432,7 +432,6 @@ typedef struct _GLFWwindowWayland
         _GLFWfallbackEdgeWayland    top, left, right, bottom;
         double                      pointerX, pointerY;
         uint32_t                    buttonPressSerial;
-        const char*                 cursorName;
     } fallback;
 
     uint32_t                        resizeEdge;

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -356,10 +356,7 @@ typedef struct _GLFWofferWayland
     struct wl_data_offer*       offer;
     GLFWbool                    text_plain_utf8;
     GLFWbool                    text_uri_list;
-    // Marker for our self-initiated toplevel drag (see glfwDragWindow on
-    // Wayland). Whenever we see an offer advertising this mime type we
-    // accept it so the compositor delivers motion events to us while the
-    // dragged toplevel is following the cursor via xdg_toplevel_drag_v1.
+    // Set when the offer advertises our toplevel-drag marker mime.
     GLFWbool                    glfw_window_drag;
 } _GLFWofferWayland;
 
@@ -408,28 +405,20 @@ typedef struct _GLFWwindowWayland
         uint32_t                decorationMode;
     } xdg;
 
-    // Set via glfwSetWindowPos before shell objects exist. Used as the
-    // anchor-rect origin (relative to the parent toplevel) when this window
-    // is created as an xdg_popup.
+    // Parent-relative position; doubles as xdg_popup anchor-rect origin.
     int                         pendingPosX, pendingPosY;
     GLFWbool                    pendingPosSet;
 
-    // Set on the first wl_surface.frame fire, which only happens after the
-    // compositor has processed a real buffer commit (Vulkan's first present).
-    // xdg_toplevel.move against an unmapped surface has been observed to
-    // crash KWin, so we defer the request until this is true.
+    // True after the first wl_surface.frame callback (first buffer
+    // committed). Drag requests are deferred until then to avoid crashing
+    // KWin with xdg_toplevel.move on an unmapped surface.
     GLFWbool                    mapped;
     struct wl_callback*         mappedCallback;
 
-    // Captured from wndconfig.focused at create time. Callers that create
-    // secondary/transient windows should set GLFW_FOCUSED=false; top-level
-    // application windows leave the default `true`. Gives us a reliable
-    // "this is a secondary window" marker that survives mapping, so we can
-    // apply set_parent and other secondary-window behavior later.
+    // GLFW_FOCUSED was false at create time, i.e. a secondary window.
     GLFWbool                    createdUnfocused;
 
-    // If glfwDragWindow was called before the surface was mapped, the press
-    // serial is stashed here and the move is issued from the map callback.
+    // Deferred drag: serial is stashed here until the map callback fires.
     GLFWbool                    dragPending;
     uint32_t                    dragPendingSerial;
 
@@ -506,11 +495,8 @@ typedef struct _GLFWlibraryWayland
     _GLFWwindow*                dragFocus;
     uint32_t                    dragSerial;
 
-    // Self-initiated window-drag session via xdg_toplevel_drag_v1. Set up by
-    // _glfwDragWindowWayland when the manager global is available. While the
-    // session is active, DnD motion events over this client's surfaces are
-    // converted into cursor-move events so the application can hit-test for
-    // drop targets even though pointer input is captured by the drag.
+    // Active xdg_toplevel_drag_v1 session (drag-and-drop motion forwarded as cursor
+    // events so the app can hit-test drop targets during the drag).
     struct {
         struct wl_data_source*          source;
         struct xdg_toplevel_drag_v1*    drag;
@@ -527,26 +513,12 @@ typedef struct _GLFWlibraryWayland
     int                         cursorTimerfd;
     uint32_t                    serial;
     uint32_t                    pointerEnterSerial;
-    // Most-recently-received wl_pointer.button press serial. xdg_toplevel.move
-    // and xdg_popup.grab both require a serial tied to a user press event;
-    // _glfw.wl.serial is the latest serial of *any* kind (motion, enter,
-    // keyboard), which is invalid for those requests and can crash strict
-    // compositors (KWin has been observed to crash).
+    // Press-event serial (not generic serial) -- required by
+    // xdg_toplevel.move, xdg_popup.grab, and start_drag.
     uint32_t                    pointerButtonSerial;
-    // Surface that received the press associated with pointerButtonSerial.
-    // Used as the `origin` for wl_data_device.start_drag — the compositor
-    // rejects (silently) any drag whose origin doesn't match the pressed
-    // surface tied to the serial.
     struct wl_surface*          pointerButtonSurface;
-    // Cursor position (surface-local, logical) at the moment of the most
-    // recent press. Used as the attach offset for xdg_toplevel_drag_v1 so
-    // the compositor keeps the cursor where the user clicked rather than
-    // snapping to the window's top-left. Must be sampled at press time
-    // because cursorPosX/Y drifts between press and drag-start.
+    // Surface-local cursor pos at press time, for drag attach offset.
     double                      pointerButtonX, pointerButtonY;
-    // Count of currently-held pointer buttons. Deferred drag-moves only fire
-    // while this is non-zero; otherwise the press serial is stale and passing
-    // it to xdg_toplevel.move is undefined per spec.
     int                         pointerButtonsDown;
 
     int                         keyRepeatTimerfd;

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -459,6 +459,8 @@ typedef struct _GLFWlibraryWayland
     struct zwp_idle_inhibit_manager_v1*     idleInhibitManager;
     struct xdg_activation_v1*               activationManager;
     struct wp_fractional_scale_manager_v1*  fractionalScaleManager;
+    struct wp_cursor_shape_manager_v1*      cursorShapeManager;
+    struct wp_cursor_shape_device_v1*       cursorShapeDevice;
 
     _GLFWofferWayland*          offers;
     unsigned int                offerCount;
@@ -649,6 +651,7 @@ typedef struct _GLFWcursorWayland
     int                         width, height;
     int                         xhot, yhot;
     int                         currentImage;
+    uint32_t                    cursorShape; // WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_* (0 if custom image)
 } _GLFWcursorWayland;
 
 GLFWbool _glfwConnectWayland(int platformID, _GLFWplatform* platform);

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -434,6 +434,8 @@ typedef struct _GLFWwindowWayland
         uint32_t                    buttonPressSerial;
         const char*                 cursorName;
     } fallback;
+
+    uint32_t                        resizeEdge;
 } _GLFWwindowWayland;
 
 // Wayland-specific global data

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -458,6 +458,9 @@ typedef struct _GLFWwindowWayland
     } fallback;
 
     uint32_t                        resizeEdge;
+
+    struct org_kde_kwin_shadow*     shadow;
+    struct wl_buffer*               shadowBuffers[8];
 } _GLFWwindowWayland;
 
 // Wayland-specific global data
@@ -485,6 +488,7 @@ typedef struct _GLFWlibraryWayland
     struct wp_fractional_scale_manager_v1*  fractionalScaleManager;
     struct wp_cursor_shape_manager_v1*      cursorShapeManager;
     struct wp_cursor_shape_device_v1*       cursorShapeDevice;
+    struct org_kde_kwin_shadow_manager*     shadowManager;
 
     _GLFWofferWayland*          offers;
     unsigned int                offerCount;

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -515,6 +515,7 @@ typedef struct _GLFWlibraryWayland
         struct wl_data_source*          source;
         struct xdg_toplevel_drag_v1*    drag;
         _GLFWwindow*                    window;
+        int                             offsetX, offsetY;
     } toplevelDragSession;
 
     const char*                 tag;

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -639,6 +639,7 @@ typedef struct _GLFWmonitorWayland
     int                         x;
     int                         y;
     int32_t                     scale;
+    int32_t                     fractionalScaleNumerator; // wp_fractional_scale_v1 numerator (0 = unknown, scale = N/120)
 } _GLFWmonitorWayland;
 
 // Wayland-specific per-cursor data

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -409,12 +409,17 @@ typedef struct _GLFWwindowWayland
     int                         pendingPosX, pendingPosY;
     GLFWbool                    pendingPosSet;
 
-    // Captured from wndconfig.focused at create time. ImGui's GLFW backend
-    // unconditionally calls glfwWindowHint(GLFW_FOCUSED, false) for viewports;
-    // app-created toplevels (splash, main editor) leave the default `true`.
-    // That gives us a reliable "this is an ImGui viewport" signal that doesn't
-    // depend on version-gated hints like GLFW_FOCUS_ON_SHOW.
-    GLFWbool                    createdUnfocused;
+    // Set on the first wl_surface.frame fire, which only happens after the
+    // compositor has processed a real buffer commit (Vulkan's first present).
+    // xdg_toplevel.move against an unmapped surface has been observed to
+    // crash KWin, so we defer the request until this is true.
+    GLFWbool                    mapped;
+    struct wl_callback*         mappedCallback;
+
+    // If glfwDragWindow was called before the surface was mapped, the press
+    // serial is stashed here and the move is issued from the map callback.
+    GLFWbool                    dragPending;
+    uint32_t                    dragPendingSerial;
 
     struct {
         struct libdecor_frame*  frame;
@@ -497,6 +502,16 @@ typedef struct _GLFWlibraryWayland
     int                         cursorTimerfd;
     uint32_t                    serial;
     uint32_t                    pointerEnterSerial;
+    // Most-recently-received wl_pointer.button press serial. xdg_toplevel.move
+    // and xdg_popup.grab both require a serial tied to a user press event;
+    // _glfw.wl.serial is the latest serial of *any* kind (motion, enter,
+    // keyboard), which is invalid for those requests and can crash strict
+    // compositors (KWin has been observed to crash).
+    uint32_t                    pointerButtonSerial;
+    // Count of currently-held pointer buttons. Deferred drag-moves only fire
+    // while this is non-zero; otherwise the press serial is stale and passing
+    // it to xdg_toplevel.move is undefined per spec.
+    int                         pointerButtonsDown;
 
     int                         keyRepeatTimerfd;
     int32_t                     keyRepeatRate;
@@ -696,6 +711,7 @@ void _glfwShowWindowWayland(_GLFWwindow* window);
 void _glfwHideWindowWayland(_GLFWwindow* window);
 void _glfwRequestWindowAttentionWayland(_GLFWwindow* window);
 void _glfwFocusWindowWayland(_GLFWwindow* window);
+void _glfwDragWindowWayland(_GLFWwindow* window);
 void _glfwSetWindowMonitorWayland(_GLFWwindow* window, _GLFWmonitor* monitor, int xpos, int ypos, int width, int height, int refreshRate);
 GLFWbool _glfwWindowFocusedWayland(_GLFWwindow* window);
 GLFWbool _glfwWindowIconifiedWayland(_GLFWwindow* window);

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -358,9 +358,8 @@ typedef struct _GLFWofferWayland
     GLFWbool                    text_uri_list;
     // Marker for our self-initiated toplevel drag (see glfwDragWindow on
     // Wayland). Whenever we see an offer advertising this mime type we
-    // accept it so the compositor delivers motion events to us — which lets
-    // ImGui detect dock targets while the dragged toplevel is following
-    // the cursor via xdg_toplevel_drag_v1.
+    // accept it so the compositor delivers motion events to us while the
+    // dragged toplevel is following the cursor via xdg_toplevel_drag_v1.
     GLFWbool                    glfw_window_drag;
 } _GLFWofferWayland;
 
@@ -421,6 +420,13 @@ typedef struct _GLFWwindowWayland
     // crash KWin, so we defer the request until this is true.
     GLFWbool                    mapped;
     struct wl_callback*         mappedCallback;
+
+    // Captured from wndconfig.focused at create time. Callers that create
+    // secondary/transient windows should set GLFW_FOCUSED=false; top-level
+    // application windows leave the default `true`. Gives us a reliable
+    // "this is a secondary window" marker that survives mapping, so we can
+    // apply set_parent and other secondary-window behavior later.
+    GLFWbool                    createdUnfocused;
 
     // If glfwDragWindow was called before the surface was mapped, the press
     // serial is stashed here and the move is issued from the map callback.
@@ -503,9 +509,8 @@ typedef struct _GLFWlibraryWayland
     // Self-initiated window-drag session via xdg_toplevel_drag_v1. Set up by
     // _glfwDragWindowWayland when the manager global is available. While the
     // session is active, DnD motion events over this client's surfaces are
-    // converted into cursor-move events so ImGui (or any app) can detect
-    // drop targets (dock bars, etc.) even though pointer input is captured
-    // by the drag.
+    // converted into cursor-move events so the application can hit-test for
+    // drop targets even though pointer input is captured by the drag.
     struct {
         struct wl_data_source*          source;
         struct xdg_toplevel_drag_v1*    drag;
@@ -532,6 +537,12 @@ typedef struct _GLFWlibraryWayland
     // rejects (silently) any drag whose origin doesn't match the pressed
     // surface tied to the serial.
     struct wl_surface*          pointerButtonSurface;
+    // Cursor position (surface-local, logical) at the moment of the most
+    // recent press. Used as the attach offset for xdg_toplevel_drag_v1 so
+    // the compositor keeps the cursor where the user clicked rather than
+    // snapping to the window's top-left. Must be sampled at press time
+    // because cursorPosX/Y drifts between press and drag-start.
+    double                      pointerButtonX, pointerButtonY;
     // Count of currently-held pointer buttons. Deferred drag-moves only fire
     // while this is non-zero; otherwise the press serial is stale and passing
     // it to xdg_toplevel.move is undefined per spec.

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -312,6 +312,7 @@ typedef void (* PFN_libdecor_frame_set_capabilities)(struct libdecor_frame*,enum
 typedef void (* PFN_libdecor_frame_unset_capabilities)(struct libdecor_frame*,enum libdecor_capabilities);
 typedef void (* PFN_libdecor_frame_set_visibility)(struct libdecor_frame*,bool visible);
 typedef struct xdg_toplevel* (* PFN_libdecor_frame_get_xdg_toplevel)(struct libdecor_frame*);
+typedef struct xdg_surface* (* PFN_libdecor_frame_get_xdg_surface)(struct libdecor_frame*);
 typedef bool (* PFN_libdecor_configuration_get_content_size)(struct libdecor_configuration*,struct libdecor_frame*,int*,int*);
 typedef bool (* PFN_libdecor_configuration_get_window_state)(struct libdecor_configuration*,enum libdecor_window_state*);
 typedef struct libdecor_state* (* PFN_libdecor_state_new)(int,int);
@@ -337,6 +338,7 @@ typedef void (* PFN_libdecor_state_free)(struct libdecor_state*);
 #define libdecor_frame_unset_capabilities _glfw.wl.libdecor.libdecor_frame_unset_capabilities_
 #define libdecor_frame_set_visibility _glfw.wl.libdecor.libdecor_frame_set_visibility_
 #define libdecor_frame_get_xdg_toplevel _glfw.wl.libdecor.libdecor_frame_get_xdg_toplevel_
+#define libdecor_frame_get_xdg_surface _glfw.wl.libdecor.libdecor_frame_get_xdg_surface_
 #define libdecor_configuration_get_content_size _glfw.wl.libdecor.libdecor_configuration_get_content_size_
 #define libdecor_configuration_get_window_state _glfw.wl.libdecor.libdecor_configuration_get_window_state_
 #define libdecor_state_new _glfw.wl.libdecor.libdecor_state_new_
@@ -396,9 +398,23 @@ typedef struct _GLFWwindowWayland
     struct {
         struct xdg_surface*     surface;
         struct xdg_toplevel*    toplevel;
+        struct xdg_popup*       popup;
         struct zxdg_toplevel_decoration_v1* decoration;
         uint32_t                decorationMode;
     } xdg;
+
+    // Set via glfwSetWindowPos before shell objects exist. Used as the
+    // anchor-rect origin (relative to the parent toplevel) when this window
+    // is created as an xdg_popup.
+    int                         pendingPosX, pendingPosY;
+    GLFWbool                    pendingPosSet;
+
+    // Captured from wndconfig.focused at create time. ImGui's GLFW backend
+    // unconditionally calls glfwWindowHint(GLFW_FOCUSED, false) for viewports;
+    // app-created toplevels (splash, main editor) leave the default `true`.
+    // That gives us a reliable "this is an ImGui viewport" signal that doesn't
+    // depend on version-gated hints like GLFW_FOCUS_ON_SHOW.
+    GLFWbool                    createdUnfocused;
 
     struct {
         struct libdecor_frame*  frame;
@@ -621,6 +637,7 @@ typedef struct _GLFWlibraryWayland
         PFN_libdecor_frame_unset_capabilities libdecor_frame_unset_capabilities_;
         PFN_libdecor_frame_set_visibility libdecor_frame_set_visibility_;
         PFN_libdecor_frame_get_xdg_toplevel libdecor_frame_get_xdg_toplevel_;
+        PFN_libdecor_frame_get_xdg_surface libdecor_frame_get_xdg_surface_;
         PFN_libdecor_configuration_get_content_size libdecor_configuration_get_content_size_;
         PFN_libdecor_configuration_get_window_state libdecor_configuration_get_window_state_;
         PFN_libdecor_state_new libdecor_state_new_;

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -446,6 +446,10 @@ typedef struct _GLFWwindowWayland
     struct zwp_locked_pointer_v1*   lockedPointer;
     struct zwp_confined_pointer_v1* confinedPointer;
 
+    GLFWbool                        cursorPosHintSet;
+    double                          cursorPosHintX;
+    double                          cursorPosHintY;
+
     struct zwp_idle_inhibitor_v1*   idleInhibitor;
     struct xdg_activation_token_v1* activationToken;
 

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -402,9 +402,6 @@ typedef struct _GLFWwindowWayland
         struct xdg_surface*     surface;
         struct xdg_toplevel*    toplevel;
         struct xdg_popup*       popup;
-        // Window whose surface this popup is parented to. Used to destroy child
-        // popups before their parent (Wayland requires LIFO popup teardown).
-        _GLFWwindow*            popupParent;
         struct zxdg_toplevel_decoration_v1* decoration;
         uint32_t                decorationMode;
     } xdg;

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -525,6 +525,8 @@ typedef struct _GLFWlibraryWayland
     // Surface-local cursor pos at press time, for drag attach offset.
     double                      pointerButtonX, pointerButtonY;
     int                         pointerButtonsDown;
+    uint32_t                    titlebarClickTime;
+    _GLFWwindow*                titlebarClickWindow;
 
     int                         keyRepeatTimerfd;
     int32_t                     keyRepeatRate;
@@ -547,6 +549,7 @@ typedef struct _GLFWlibraryWayland
         double                  discreteY;
         int                     button;
         int                     action;
+        uint32_t                buttonTime;
     } pending;
 
     struct {

--- a/src/wl_platform.h
+++ b/src/wl_platform.h
@@ -402,6 +402,9 @@ typedef struct _GLFWwindowWayland
         struct xdg_surface*     surface;
         struct xdg_toplevel*    toplevel;
         struct xdg_popup*       popup;
+        // Window whose surface this popup is parented to. Used to destroy child
+        // popups before their parent (Wayland requires LIFO popup teardown).
+        _GLFWwindow*            popupParent;
         struct zxdg_toplevel_decoration_v1* decoration;
         uint32_t                decorationMode;
     } xdg;

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -2766,6 +2766,20 @@ static void dataDeviceHandleEnter(void* userData,
                 const double xpos = wl_fixed_to_double(x);
                 const double ypos = wl_fixed_to_double(y);
                 _glfwInputCursorPos(window, xpos, ypos);
+
+                // Re-sync dragged window position (see dataDeviceHandleMotion)
+                _GLFWwindow* dragged = _glfw.wl.toplevelDragSession.window;
+                if (dragged)
+                {
+                    int newX = window->wl.pendingPosX
+                             + (int) lround(xpos) - _glfw.wl.toplevelDragSession.offsetX;
+                    int newY = window->wl.pendingPosY
+                             + (int) lround(ypos) - _glfw.wl.toplevelDragSession.offsetY;
+                    dragged->wl.pendingPosX = newX;
+                    dragged->wl.pendingPosY = newY;
+                    dragged->wl.pendingPosSet = GLFW_TRUE;
+                    _glfwInputWindowPos(dragged, newX, newY);
+                }
             }
         }
     }
@@ -2822,6 +2836,28 @@ static void dataDeviceHandleMotion(void* userData,
         const double xpos = wl_fixed_to_double(x);
         const double ypos = wl_fixed_to_double(y);
         _glfwInputCursorPos(_glfw.wl.dragFocus, xpos, ypos);
+
+        // Re-synchronize the dragged window's stored position from the
+        // compositor's actual placement.  The cursor is at (xpos, ypos) in
+        // dragFocus's surface frame and the dragged toplevel was attached
+        // at (offsetX, offsetY) from the cursor, so the dragged window's
+        // origin is at (cursor - offset) relative to dragFocus's origin.
+        _GLFWwindow* dragged = _glfw.wl.toplevelDragSession.window;
+        if (dragged && _glfw.wl.dragFocus != dragged)
+        {
+            int newX = _glfw.wl.dragFocus->wl.pendingPosX
+                     + (int) lround(xpos) - _glfw.wl.toplevelDragSession.offsetX;
+            int newY = _glfw.wl.dragFocus->wl.pendingPosY
+                     + (int) lround(ypos) - _glfw.wl.toplevelDragSession.offsetY;
+            if (newX != dragged->wl.pendingPosX ||
+                newY != dragged->wl.pendingPosY)
+            {
+                dragged->wl.pendingPosX = newX;
+                dragged->wl.pendingPosY = newY;
+                dragged->wl.pendingPosSet = GLFW_TRUE;
+                _glfwInputWindowPos(dragged, newX, newY);
+            }
+        }
     }
 }
 
@@ -3590,6 +3626,8 @@ static GLFWbool startToplevelDragSession(_GLFWwindow* window, uint32_t serial)
     int offsetY = (int) lround(rawOffsetY);
     if (offsetX < 0) offsetX = 0;
     if (offsetY < 0) offsetY = 0;
+    _glfw.wl.toplevelDragSession.offsetX = offsetX;
+    _glfw.wl.toplevelDragSession.offsetY = offsetY;
     xdg_toplevel_drag_v1_attach(drag, toplevel, offsetX, offsetY);
 
     struct wl_surface* origin = _glfw.wl.pointerButtonSurface;

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -1683,7 +1683,8 @@ static void updateResizeEdge(_GLFWwindow* window)
 {
     uint32_t edge = XDG_TOPLEVEL_RESIZE_EDGE_NONE;
 
-    if (window->resizable && !window->decorated && !window->monitor)
+    if (window->resizable && !window->decorated && !window->monitor &&
+        !window->wl.maximized && !window->wl.fullscreen)
     {
         edge = detectResizeEdge(window,
                                 (int) window->wl.cursorPosX,
@@ -1732,7 +1733,8 @@ static void processPointerButton(int button, int action)
         GLFWbool handled = GLFW_FALSE;
 
         if (button == GLFW_MOUSE_BUTTON_LEFT && action == GLFW_PRESS &&
-            !window->decorated && !window->monitor)
+            !window->decorated && !window->monitor &&
+            !window->wl.maximized && !window->wl.fullscreen)
         {
             struct xdg_toplevel* toplevel = window->wl.xdg.toplevel;
             if (window->wl.libdecor.frame)

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -284,6 +284,43 @@ static void destroyFallbackDecorations(_GLFWwindow* window)
     destroyFallbackEdge(&window->wl.fallback.bottom);
 }
 
+static void setNamedCursor(_GLFWwindow* window, const char* cursorName)
+{
+    struct wl_surface* surface = _glfw.wl.cursorSurface;
+    struct wl_cursor_theme* theme = _glfw.wl.cursorTheme;
+    int scale = 1;
+
+    if (window->wl.bufferScale > 1 && _glfw.wl.cursorThemeHiDPI)
+    {
+        // We only support up to scale=2 for now, since libwayland-cursor
+        // requires us to load a different theme for each size.
+        scale = 2;
+        theme = _glfw.wl.cursorThemeHiDPI;
+    }
+
+    struct wl_cursor* cursor = wl_cursor_theme_get_cursor(theme, cursorName);
+    if (!cursor)
+        return;
+
+    // TODO: handle animated cursors too.
+    struct wl_cursor_image* image = cursor->images[0];
+    if (!image)
+        return;
+
+    struct wl_buffer* buffer = wl_cursor_image_get_buffer(image);
+    if (!buffer)
+        return;
+
+    wl_pointer_set_cursor(_glfw.wl.pointer, _glfw.wl.pointerEnterSerial,
+                          surface,
+                          image->hotspot_x / scale,
+                          image->hotspot_y / scale);
+    wl_surface_set_buffer_scale(surface, scale);
+    wl_surface_attach(surface, buffer, 0, 0);
+    wl_surface_damage(surface, 0, 0, image->width, image->height);
+    wl_surface_commit(surface);
+}
+
 static void updateFallbackDecorationCursor(_GLFWwindow* window, double xpos, double ypos)
 {
     window->wl.fallback.pointerX = xpos;
@@ -325,40 +362,7 @@ static void updateFallbackDecorationCursor(_GLFWwindow* window, double xpos, dou
 
     if (window->wl.fallback.cursorName != cursorName)
     {
-        struct wl_surface* surface = _glfw.wl.cursorSurface;
-        struct wl_cursor_theme* theme = _glfw.wl.cursorTheme;
-        int scale = 1;
-
-        if (window->wl.bufferScale > 1 && _glfw.wl.cursorThemeHiDPI)
-        {
-            // We only support up to scale=2 for now, since libwayland-cursor
-            // requires us to load a different theme for each size.
-            scale = 2;
-            theme = _glfw.wl.cursorThemeHiDPI;
-        }
-
-        struct wl_cursor* cursor = wl_cursor_theme_get_cursor(theme, cursorName);
-        if (!cursor)
-            return;
-
-        // TODO: handle animated cursors too.
-        struct wl_cursor_image* image = cursor->images[0];
-        if (!image)
-            return;
-
-        struct wl_buffer* buffer = wl_cursor_image_get_buffer(image);
-        if (!buffer)
-            return;
-
-        wl_pointer_set_cursor(_glfw.wl.pointer, _glfw.wl.pointerEnterSerial,
-                              surface,
-                              image->hotspot_x / scale,
-                              image->hotspot_y / scale);
-        wl_surface_set_buffer_scale(surface, scale);
-        wl_surface_attach(surface, buffer, 0, 0);
-        wl_surface_damage(surface, 0, 0, image->width, image->height);
-        wl_surface_commit(surface);
-
+        setNamedCursor(window, cursorName);
         window->wl.fallback.cursorName = cursorName;
     }
 }
@@ -1538,12 +1542,72 @@ static void processPointerLeaveSurface(struct wl_surface* surface)
 
     _GLFWwindow* window = wl_surface_get_user_data(surface);
     if (window->wl.surface == surface)
+    {
+        window->wl.resizeEdge = XDG_TOPLEVEL_RESIZE_EDGE_NONE;
         _glfwInputCursorEnter(window, GLFW_FALSE);
+    }
     else
     {
         if (window->wl.fallback.decorations)
             window->wl.fallback.cursorName = NULL;
     }
+}
+
+static uint32_t detectResizeEdge(_GLFWwindow* window, int x, int y)
+{
+    const int w = window->wl.width;
+    const int h = window->wl.height;
+    const int border = 8;
+
+    const GLFWbool onLeft   = (x < border);
+    const GLFWbool onRight  = (x >= w - border);
+    const GLFWbool onTop    = (y < border);
+    const GLFWbool onBottom = (y >= h - border);
+
+    if      (onTop    && onLeft)  return XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT;
+    else if (onTop    && onRight) return XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT;
+    else if (onBottom && onLeft)  return XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT;
+    else if (onBottom && onRight) return XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT;
+    else if (onTop)               return XDG_TOPLEVEL_RESIZE_EDGE_TOP;
+    else if (onBottom)            return XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM;
+    else if (onLeft)              return XDG_TOPLEVEL_RESIZE_EDGE_LEFT;
+    else if (onRight)             return XDG_TOPLEVEL_RESIZE_EDGE_RIGHT;
+
+    return XDG_TOPLEVEL_RESIZE_EDGE_NONE;
+}
+
+static const char* resizeEdgeCursorName(uint32_t edge)
+{
+    switch (edge)
+    {
+        case XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT:     return "nw-resize";
+        case XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT:    return "ne-resize";
+        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT:  return "sw-resize";
+        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT: return "se-resize";
+        case XDG_TOPLEVEL_RESIZE_EDGE_TOP:          return "n-resize";
+        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM:       return "s-resize";
+        case XDG_TOPLEVEL_RESIZE_EDGE_LEFT:         return "w-resize";
+        case XDG_TOPLEVEL_RESIZE_EDGE_RIGHT:        return "e-resize";
+        default:                                    return NULL;
+    }
+}
+
+static void updateResizeEdge(_GLFWwindow* window)
+{
+    uint32_t edge = XDG_TOPLEVEL_RESIZE_EDGE_NONE;
+
+    if (window->resizable && !window->decorated && !window->monitor)
+    {
+        edge = detectResizeEdge(window,
+                                (int) window->wl.cursorPosX,
+                                (int) window->wl.cursorPosY);
+    }
+
+    if (edge == window->wl.resizeEdge)
+        return;
+
+    window->wl.resizeEdge = edge;
+    _glfwSetCursorWayland(window, window->cursor);
 }
 
 static void processPointerMotion(double xpos, double ypos)
@@ -1556,6 +1620,7 @@ static void processPointerMotion(double xpos, double ypos)
             window->wl.cursorPosX = xpos;
             window->wl.cursorPosY = ypos;
             _glfwInputCursorPos(window, window->wl.cursorPosX, window->wl.cursorPosY);
+            updateResizeEdge(window);
         }
     }
     else
@@ -1570,28 +1635,47 @@ static void processPointerButton(int button, int action)
     _GLFWwindow* window = wl_surface_get_user_data(_glfw.wl.pointerSurface);
     if (window->wl.surface == _glfw.wl.pointerSurface)
     {
-        // For undecorated windows, check titlebar hit test on left-click
-        // to initiate compositor-driven window drag (mirrors the X11 path)
-        if (button == GLFW_MOUSE_BUTTON_LEFT && action == GLFW_PRESS && !window->decorated)
+        // For undecorated windows, provide OS-level resize borders
+        // and titlebar drag via xdg_toplevel — matching the X11
+        // _NET_WM_MOVERESIZE behaviour
+        GLFWbool handled = GLFW_FALSE;
+
+        if (button == GLFW_MOUSE_BUTTON_LEFT && action == GLFW_PRESS &&
+            !window->decorated && !window->monitor)
         {
-            int titlebarHit = 0;
-            _glfwInputTitleBarHitTest(window, (int) window->wl.cursorPosX, (int) window->wl.cursorPosY, &titlebarHit);
+            struct xdg_toplevel* toplevel = window->wl.xdg.toplevel;
+            if (window->wl.libdecor.frame)
+                toplevel = libdecor_frame_get_xdg_toplevel(window->wl.libdecor.frame);
 
-            if (titlebarHit)
+            if (toplevel)
             {
-                struct xdg_toplevel* toplevel = window->wl.xdg.toplevel;
-                if (window->wl.libdecor.frame)
-                    toplevel = libdecor_frame_get_xdg_toplevel(window->wl.libdecor.frame);
+                const int x = (int) window->wl.cursorPosX;
+                const int y = (int) window->wl.cursorPosY;
+                uint32_t edges = window->resizable
+                    ? detectResizeEdge(window, x, y)
+                    : XDG_TOPLEVEL_RESIZE_EDGE_NONE;
 
-                if (toplevel)
+                if (edges != XDG_TOPLEVEL_RESIZE_EDGE_NONE)
                 {
-                    xdg_toplevel_move(toplevel, _glfw.wl.seat, _glfw.wl.serial);
-                    return;
+                    xdg_toplevel_resize(toplevel, _glfw.wl.seat,
+                                        _glfw.wl.serial, edges);
+                    handled = GLFW_TRUE;
+                }
+                else
+                {
+                    int titlebarHit = 0;
+                    _glfwInputTitleBarHitTest(window, x, y, &titlebarHit);
+                    if (titlebarHit)
+                    {
+                        xdg_toplevel_move(toplevel, _glfw.wl.seat, _glfw.wl.serial);
+                        handled = GLFW_TRUE;
+                    }
                 }
             }
         }
 
-        _glfwInputMouseClick(window, button, action, _glfw.wl.xkb.modifiers);
+        if (!handled)
+            _glfwInputMouseClick(window, button, action, _glfw.wl.xkb.modifiers);
     }
     else
     {
@@ -3340,7 +3424,12 @@ void _glfwSetCursorWayland(_GLFWwindow* window, _GLFWcursor* cursor)
     if (window->cursorMode == GLFW_CURSOR_NORMAL ||
         window->cursorMode == GLFW_CURSOR_CAPTURED)
     {
-        if (cursor)
+        // Resize edge cursor takes priority over the application cursor
+        if (window->wl.resizeEdge != XDG_TOPLEVEL_RESIZE_EDGE_NONE)
+        {
+            setNamedCursor(window, resizeEdgeCursorName(window->wl.resizeEdge));
+        }
+        else if (cursor)
             setCursorImage(window, &cursor->wl);
         else
         {

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -32,6 +32,8 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <math.h>
+#include <float.h>
 #include <errno.h>
 #include <assert.h>
 #include <unistd.h>
@@ -1139,6 +1141,8 @@ static const struct libdecor_frame_interface libdecorFrameInterface =
     libdecorFrameHandleDismissPopup
 };
 
+static _GLFWwindow* findWaylandPopupParent(_GLFWwindow* self);
+
 static GLFWbool createLibdecorFrame(_GLFWwindow* window)
 {
     // Allow libdecor to finish initialization of itself and its plugin
@@ -1203,6 +1207,25 @@ static GLFWbool createLibdecorFrame(_GLFWwindow* window)
             libdecor_frame_set_visibility(window->wl.libdecor.frame, false);
 
         setIdleInhibitor(window, GLFW_FALSE);
+    }
+
+    // Parent secondary libdecor toplevels to the first existing toplevel.
+    // See the matching comment in createXdgShellObjects. libdecor exposes the
+    // underlying xdg_toplevel via get_xdg_toplevel, so we set the parent on
+    // that directly.
+    if (window->wl.createdUnfocused && !window->monitor)
+    {
+        _GLFWwindow* parent = findWaylandPopupParent(window);
+        if (parent)
+        {
+            struct xdg_toplevel* parentToplevel = parent->wl.xdg.toplevel;
+            if (!parentToplevel && parent->wl.libdecor.frame)
+                parentToplevel = libdecor_frame_get_xdg_toplevel(parent->wl.libdecor.frame);
+            struct xdg_toplevel* ownToplevel =
+                libdecor_frame_get_xdg_toplevel(window->wl.libdecor.frame);
+            if (parentToplevel && ownToplevel)
+                xdg_toplevel_set_parent(ownToplevel, parentToplevel);
+        }
     }
 
     libdecor_frame_map(window->wl.libdecor.frame);
@@ -1281,8 +1304,8 @@ static void xdgPopupHandleConfigure(void* userData,
                                     int32_t x, int32_t y,
                                     int32_t width, int32_t height)
 {
-    // Compositor-confirmed popup geometry. ImGui already has its own layout,
-    // so nothing to propagate here beyond the surface-level size sync.
+    // Compositor-confirmed popup geometry. Propagate surface-level size sync
+    // so the framebuffer stays in step with the compositor's view.
     _GLFWwindow* window = userData;
     if (width > 0 && height > 0 &&
         (width != window->wl.width || height != window->wl.height))
@@ -1297,7 +1320,8 @@ static void xdgPopupHandleConfigure(void* userData,
 static void xdgPopupHandlePopupDone(void* userData, struct xdg_popup* popup)
 {
     // Compositor dismissed the popup (e.g. user clicked outside). Ask the
-    // owning application to close the window; ImGui will tear down the viewport.
+    // owning application to close the window; it is responsible for
+    // teardown.
     _GLFWwindow* window = userData;
     _glfwInputWindowCloseRequest(window);
 }
@@ -1371,9 +1395,8 @@ static GLFWbool createXdgPopupShellObjects(_GLFWwindow* window,
     xdg_positioner_set_size(positioner, w, h);
 
     // Treat the coords handed to glfwSetWindowPos as parent-relative, because
-    // on Wayland there is no global coordinate space. ImGui's main viewport
-    // lives at (0, 0) in its own space, so menus/tooltips positioned against
-    // it already carry correct parent-relative offsets.
+    // on Wayland there is no global coordinate space. Callers are expected
+    // to supply coordinates in the parent window's local frame.
     const int px = window->wl.pendingPosSet ? window->wl.pendingPosX : 0;
     const int py = window->wl.pendingPosSet ? window->wl.pendingPosY : 0;
     xdg_positioner_set_anchor_rect(positioner, px, py, 1, 1);
@@ -1438,6 +1461,25 @@ static GLFWbool createXdgShellObjects(_GLFWwindow* window)
         xdg_toplevel_set_app_id(window->wl.xdg.toplevel, window->wl.appId);
 
     xdg_toplevel_set_title(window->wl.xdg.toplevel, window->title);
+
+    // Parent secondary toplevels (created with GLFW_FOCUSED=false) to the
+    // first existing application toplevel so the compositor keeps them
+    // logically grouped. Concretely, during a DnD-based drag
+    // (xdg_toplevel_drag_v1), the compositor typically raises the hovered
+    // window's app to the front; without set_parent, the primary window
+    // gets left behind when the cursor passes over other apps.
+    if (window->wl.createdUnfocused && !window->monitor)
+    {
+        _GLFWwindow* parent = findWaylandPopupParent(window);
+        if (parent)
+        {
+            struct xdg_toplevel* parentToplevel = parent->wl.xdg.toplevel;
+            if (!parentToplevel && parent->wl.libdecor.frame)
+                parentToplevel = libdecor_frame_get_xdg_toplevel(parent->wl.libdecor.frame);
+            if (parentToplevel)
+                xdg_toplevel_set_parent(window->wl.xdg.toplevel, parentToplevel);
+        }
+    }
 
     if (window->monitor)
     {
@@ -1547,8 +1589,8 @@ static void armMappedFrameCallback(_GLFWwindow* window)
 static GLFWbool createShellObjects(_GLFWwindow* window)
 {
     // Opt into xdg_popup for windows the caller marked as menu-style via
-    // GLFW_FOCUS_ON_SHOW=false. Undecorated alone isn't enough — detached
-    // dockable viewports are also undecorated but should remain real
+    // GLFW_FOCUS_ON_SHOW=false. Undecorated alone isn't enough — other
+    // secondary toplevels may also be undecorated but should remain real
     // toplevels so they can be moved by the compositor (xdg_toplevel.move)
     // and participate in normal window stacking.
     if (!window->focusOnShow && !window->decorated && !window->monitor)
@@ -2137,6 +2179,17 @@ static void pointerHandleButton(void* userData,
     {
         _glfw.wl.pointerButtonSerial = serial;
         _glfw.wl.pointerButtonSurface = _glfw.wl.pointerSurface;
+        if (_glfw.wl.pointerSurface &&
+            wl_proxy_get_tag((struct wl_proxy*) _glfw.wl.pointerSurface)
+                == &_glfw.wl.tag)
+        {
+            _GLFWwindow* w = wl_surface_get_user_data(_glfw.wl.pointerSurface);
+            if (w)
+            {
+                _glfw.wl.pointerButtonX = w->wl.cursorPosX;
+                _glfw.wl.pointerButtonY = w->wl.cursorPosY;
+            }
+        }
         _glfw.wl.pointerButtonsDown++;
     }
     else if (_glfw.wl.pointerButtonsDown > 0)
@@ -2688,12 +2741,16 @@ static void dataDeviceHandleEnter(void* userData,
 
                 wl_data_offer_accept(offer, serial, "text/uri-list");
             }
-            else if (_glfw.wl.offers[i].glfw_window_drag)
+            else if (_glfw.wl.offers[i].glfw_window_drag &&
+                     window != _glfw.wl.toplevelDragSession.window)
             {
-                // Our own xdg_toplevel_drag session. Accept so the compositor
-                // keeps sending motion events to this surface, and prime the
-                // cursor position so the app sees the drag entering this
-                // window.
+                // Our own xdg_toplevel_drag session. Ignore enters on the
+                // *dragged* window itself — per the xdg-shell spec the
+                // attached toplevel doesn't participate in drop-target
+                // selection, but KWin has been observed to deliver DnD
+                // events to it anyway. Forwarding those as cursor motion
+                // would trigger hover effects on the dragged window's own
+                // widgets while the user is dragging.
                 _glfw.wl.dragOffer = offer;
                 _glfw.wl.dragFocus = window;
                 _glfw.wl.dragSerial = serial;
@@ -2726,6 +2783,22 @@ static void dataDeviceHandleEnter(void* userData,
 static void dataDeviceHandleLeave(void* userData,
                                   struct wl_data_device* device)
 {
+    // During our own toplevel drag, park the reported cursor position far
+    // off-screen while the cursor is outside all of our surfaces. The value
+    // is chosen to be large-negative but not close to float limits, so
+    // applications that treat extreme positions as "invalid" (and would
+    // tear down drag state) see it as valid-but-nowhere, letting the drag
+    // stay live and tracking resume on re-entry. Also invalidate the cached
+    // virtual pos so the next enter's _glfwInputCursorPos doesn't early-out
+    // on a coord match.
+    if (_glfw.wl.toplevelDragSession.source && _glfw.wl.dragFocus)
+    {
+        _GLFWwindow* focus = _glfw.wl.dragFocus;
+        focus->virtualCursorPosX = -DBL_MAX;
+        focus->virtualCursorPosY = -DBL_MAX;
+        _glfwInputCursorPos(focus, -100000.0, -100000.0);
+    }
+
     if (_glfw.wl.dragOffer)
     {
         wl_data_offer_destroy(_glfw.wl.dragOffer);
@@ -2743,7 +2816,7 @@ static void dataDeviceHandleMotion(void* userData,
     // During our own toplevel drag, the compositor captures pointer input,
     // so wl_pointer.motion never fires. Forward the DnD motion as a cursor
     // move so the client sees the drag passing over its surfaces and can
-    // drive drop-target hit-testing (dock regions, etc.) in ImGui.
+    // drive drop-target hit-testing.
     if (_glfw.wl.dragFocus && _glfw.wl.toplevelDragSession.source)
     {
         const double xpos = wl_fixed_to_double(x);
@@ -2914,6 +2987,8 @@ GLFWbool _glfwCreateWindowWayland(_GLFWwindow* window,
                                   const _GLFWctxconfig* ctxconfig,
                                   const _GLFWfbconfig* fbconfig)
 {
+    window->wl.createdUnfocused = !wndconfig->focused;
+
     if (!createNativeSurface(window, wndconfig, fbconfig))
         return GLFW_FALSE;
 
@@ -2984,6 +3059,16 @@ GLFWbool _glfwCreateWindowWayland(_GLFWwindow* window,
 
 void _glfwDestroyWindowWayland(_GLFWwindow* window)
 {
+    // If any drag-session state pointed at this window, clear it now.
+    // Otherwise end-of-drag callbacks (endToplevelDragSession, DnD motion
+    // forwarding) would try to synthesize input events on the freed window
+    // — which can happen when the application destroys an OS window while
+    // the compositor still holds a drag open on it.
+    if (_glfw.wl.toplevelDragSession.window == window)
+        _glfw.wl.toplevelDragSession.window = NULL;
+    if (_glfw.wl.dragFocus == window)
+        _glfw.wl.dragFocus = NULL;
+
     if (window->wl.surface == _glfw.wl.pointerSurface)
         _glfw.wl.pointerSurface = NULL;
 
@@ -3064,8 +3149,8 @@ void _glfwGetWindowPosWayland(_GLFWwindow* window, int* xpos, int* ypos)
     // we do know the requested parent-relative anchor we were created at, so
     // report that; for toplevels, there's no meaningful value to return.
     //
-    // Stay silent: ImGui's viewport code polls this every frame and the
-    // warning would flood the log.
+    // Stay silent: applications often poll this every frame and a warning
+    // would flood the log.
     if (window->wl.pendingPosSet)
     {
         if (xpos) *xpos = window->wl.pendingPosX;
@@ -3076,14 +3161,11 @@ void _glfwGetWindowPosWayland(_GLFWwindow* window, int* xpos, int* ypos)
 void _glfwSetWindowPosWayland(_GLFWwindow* window, int xpos, int ypos)
 {
     // Wayland has no global coordinate space, so we can't physically move a
-    // mapped toplevel. But we still mirror whatever the caller writes:
-    // ImGui's multi-viewport input-forwarding adds glfwGetWindowPos to each
-    // per-surface pointer coord to produce absolute coordinates, and its
-    // hit-testing assumes viewport->Pos matches that same value. The two
-    // drift together harmlessly as long as we always mirror the write;
-    // making one stable while the other isn't breaks widget clicks.
-    // Before mapping, this stashed value also feeds the xdg_popup
-    // positioner as the anchor-rect origin.
+    // mapped toplevel. But we still mirror whatever the caller writes so
+    // later glfwGetWindowPos returns what was last set — callers that use
+    // the stored position to translate per-surface pointer coordinates
+    // rely on write/read consistency. Before mapping, this stashed value
+    // also feeds the xdg_popup positioner as the anchor-rect origin.
     window->wl.pendingPosX = xpos;
     window->wl.pendingPosY = ypos;
     window->wl.pendingPosSet = GLFW_TRUE;
@@ -3359,8 +3441,7 @@ static void endToplevelDragSession(void)
         _glfw.wl.pointerButtonsDown--;
 
     // Synthesize the swallowed left-button release so the application's
-    // input pipeline gets to see "drag ended" and run its drop logic
-    // (e.g. ImGui dock-to-target detection).
+    // input pipeline gets to see "drag ended" and can run any drop logic.
     if (window)
         _glfwInputMouseClick(window, GLFW_MOUSE_BUTTON_LEFT, GLFW_RELEASE, 0);
 }
@@ -3418,8 +3499,8 @@ static const struct wl_data_source_listener dragSourceListener =
 // GLFW_TRUE on success; caller should fall back to xdg_toplevel.move otherwise.
 // The critical property of this path vs plain move: the compositor delivers
 // wl_data_device enter/motion/leave events to our surfaces under the cursor,
-// so the application can detect drop targets (e.g. dock regions) while the
-// dragged window follows the cursor.
+// so the application can detect drop targets while the dragged window
+// follows the cursor.
 static GLFWbool startToplevelDragSession(_GLFWwindow* window, uint32_t serial)
 {
     if (!_glfw.wl.toplevelDragManager ||
@@ -3478,32 +3559,35 @@ static GLFWbool startToplevelDragSession(_GLFWwindow* window, uint32_t serial)
     // Two cases:
     //  - Dragging the window that received the press (regular titlebar
     //    drag): use that window's own tracked cursor position.
-    //  - Tab-tear: the press happened on a different window (e.g. main
-    //    window's tab bar), then a new toplevel was created under the
-    //    cursor. The new toplevel hasn't received any motion events yet, so
-    //    its cursorPosX/Y is 0, which is why it grabs from the top-left.
-    //    Compute the cursor position inside the new window as the source
-    //    window's cursor pos minus the new window's caller-intended
-    //    position (ImGui wrote this via glfwSetWindowPos before show).
-    int offsetX = 0;
-    int offsetY = 0;
+    //  - Press-on-other-window: the press happened on a different window
+    //    than the one being dragged (the caller may have created a new
+    //    toplevel for the drag under the cursor). The new toplevel hasn't
+    //    received any motion events yet, so its cursorPosX/Y is 0, which
+    //    is why it grabs from the top-left. Compute the cursor position
+    //    inside the new window as the source window's cursor pos minus
+    //    the new window's caller-intended position (passed via an earlier
+    //    glfwSetWindowPos before show).
+    // Use the cursor position captured at the press itself, not the live
+    // cursor pos — it drifts between the press and when SetWindowPos
+    // actually triggers this drag, and the drift varied per-drag.
+    // Round rather than truncate so fractional cursor positions don't
+    // systematically lose a pixel to the bottom-left.
+    double rawOffsetX, rawOffsetY;
     if (_glfw.wl.pointerButtonSurface == window->wl.surface)
     {
-        offsetX = (int) window->wl.cursorPosX;
-        offsetY = (int) window->wl.cursorPosY;
+        rawOffsetX = _glfw.wl.pointerButtonX;
+        rawOffsetY = _glfw.wl.pointerButtonY;
     }
-    else if (_glfw.wl.pointerButtonSurface &&
-             wl_proxy_get_tag((struct wl_proxy*) _glfw.wl.pointerButtonSurface)
-                 == &_glfw.wl.tag)
+    else
     {
-        _GLFWwindow* src =
-            wl_surface_get_user_data(_glfw.wl.pointerButtonSurface);
-        if (src)
-        {
-            offsetX = (int)(src->wl.cursorPosX - window->wl.pendingPosX);
-            offsetY = (int)(src->wl.cursorPosY - window->wl.pendingPosY);
-        }
+        // Tab-tear: press was on a different surface (main window's tab
+        // bar). Convert the press position into the new window's surface
+        // coords by subtracting the new window's intended top-left.
+        rawOffsetX = _glfw.wl.pointerButtonX - window->wl.pendingPosX;
+        rawOffsetY = _glfw.wl.pointerButtonY - window->wl.pendingPosY;
     }
+    int offsetX = (int) lround(rawOffsetX);
+    int offsetY = (int) lround(rawOffsetY);
     if (offsetX < 0) offsetX = 0;
     if (offsetY < 0) offsetY = 0;
     xdg_toplevel_drag_v1_attach(drag, toplevel, offsetX, offsetY);
@@ -3521,9 +3605,9 @@ void _glfwDragWindowWayland(_GLFWwindow* window)
     if (!_glfw.wl.seat || !_glfw.wl.pointerButtonSerial)
         return;
 
-    // A drag session is already in flight for this window — no-op. ImGui's
-    // Platform_SetWindowPos fires each frame during its drag math, but we
-    // only want to hand the drag to the compositor once per user press.
+    // A drag session is already in flight for this window — no-op. Callers
+    // may invoke this every frame during their own drag math, but we only
+    // want to hand the drag to the compositor once per user press.
     if (_glfw.wl.toplevelDragSession.source &&
         _glfw.wl.toplevelDragSession.window == window)
     {
@@ -3533,9 +3617,9 @@ void _glfwDragWindowWayland(_GLFWwindow* window)
     // Pre-map: stash the request and let the mapped-frame callback fire it
     // once the compositor has processed the first buffer. Calling
     // xdg_toplevel.move (or starting a drag attached to an unmapped toplevel)
-    // on an unmapped surface has been observed to crash KWin. The pre-show
-    // case matters for tab-tear (caller invokes this before glfwShowWindow
-    // maps anything).
+    // on an unmapped surface has been observed to crash KWin. This matters
+    // for callers that invoke glfwDragWindow on a window they just created
+    // but haven't yet shown.
     if (!window->wl.mapped)
     {
         window->wl.dragPendingSerial = _glfw.wl.pointerButtonSerial;
@@ -3545,8 +3629,8 @@ void _glfwDragWindowWayland(_GLFWwindow* window)
 
     // Preferred path: xdg_toplevel_drag_v1 (staging) — same visual effect as
     // xdg_toplevel.move but the compositor keeps delivering DnD events to
-    // our surfaces under the cursor. That's what lets the dock system see
-    // the dragged window passing over drop targets.
+    // our surfaces under the cursor, so the application can hit-test the
+    // dragged window against drop targets.
     if (startToplevelDragSession(window, _glfw.wl.pointerButtonSerial))
         return;
 

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -51,6 +51,7 @@
 #include "xdg-activation-v1-client-protocol.h"
 #include "idle-inhibit-unstable-v1-client-protocol.h"
 #include "fractional-scale-v1-client-protocol.h"
+#include "cursor-shape-v1-client-protocol.h"
 
 #define GLFW_BORDER_SIZE    4
 #define GLFW_CAPTION_HEIGHT 24
@@ -60,6 +61,73 @@
 #define GLFW_PENDING_MOTION     4
 #define GLFW_PENDING_SCROLL     8
 #define GLFW_PENDING_DISCRETE   16
+
+// Unified cursor descriptor table.  Each row maps a GLFW standard cursor
+// shape and/or an xdg_toplevel resize edge to the wp_cursor_shape protocol
+// enum, plus XDG and X11 fallback cursor name strings for compositors that
+// don't support wp_cursor_shape_v1.
+//
+// Rows with resizeEdge == NONE are the canonical entries for a GLFW shape
+// (used by _glfwCreateStandardCursorWayland).  Rows with a specific edge
+// are used by applyCursor for directional resize cursors.
+//
+typedef struct {
+    int                 glfwShape;  // GLFW_*_CURSOR
+    uint32_t            resizeEdge; // XDG_TOPLEVEL_RESIZE_EDGE_* (NONE if N/A)
+    uint32_t            shape;      // WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_*
+    const char*         name;       // XDG cursor name
+    const char*         fallback;   // X11 core cursor name
+} _GLFWcursorDesc;
+
+static const _GLFWcursorDesc cursorTable[] =
+{
+    // Non-resize cursors
+    { GLFW_ARROW_CURSOR,         XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_DEFAULT,     "default",       "left_ptr"            },
+    { GLFW_IBEAM_CURSOR,         XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_TEXT,        "text",          "xterm"              },
+    { GLFW_CROSSHAIR_CURSOR,     XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_CROSSHAIR,   "crosshair",     "crosshair"          },
+    { GLFW_POINTING_HAND_CURSOR, XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_POINTER,     "pointer",       "hand2"              },
+    { GLFW_RESIZE_ALL_CURSOR,    XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_ALL_SCROLL,  "all-scroll",    "fleur"              },
+    { GLFW_NOT_ALLOWED_CURSOR,   XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_NOT_ALLOWED, "not-allowed",   "not-allowed"        },
+
+    // Bidirectional resize cursors (canonical GLFW entries, no specific edge)
+    { GLFW_RESIZE_EW_CURSOR,     XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_EW_RESIZE,   "ew-resize",     "sb_h_double_arrow"  },
+    { GLFW_RESIZE_NS_CURSOR,     XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_NS_RESIZE,   "ns-resize",     "sb_v_double_arrow"  },
+    { GLFW_RESIZE_NWSE_CURSOR,   XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_NWSE_RESIZE, "nwse-resize",   "nwse-resize"        },
+    { GLFW_RESIZE_NESW_CURSOR,   XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_NESW_RESIZE, "nesw-resize",   "nesw-resize"        },
+
+    // Directional resize cursors (per-edge)
+    { GLFW_RESIZE_NS_CURSOR,     XDG_TOPLEVEL_RESIZE_EDGE_TOP,         WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_N_RESIZE,    "n-resize",      "top_side"           },
+    { GLFW_RESIZE_NS_CURSOR,     XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM,      WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_S_RESIZE,    "s-resize",      "bottom_side"        },
+    { GLFW_RESIZE_EW_CURSOR,     XDG_TOPLEVEL_RESIZE_EDGE_LEFT,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_W_RESIZE,    "w-resize",      "left_side"          },
+    { GLFW_RESIZE_EW_CURSOR,     XDG_TOPLEVEL_RESIZE_EDGE_RIGHT,       WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_E_RESIZE,    "e-resize",      "right_side"         },
+    { GLFW_RESIZE_NWSE_CURSOR,   XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT,    WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_NW_RESIZE,   "nw-resize",     "top_left_corner"    },
+    { GLFW_RESIZE_NWSE_CURSOR,   XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT,WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_SE_RESIZE,   "se-resize",     "bottom_right_corner"},
+    { GLFW_RESIZE_NESW_CURSOR,   XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT,   WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_NE_RESIZE,   "ne-resize",     "top_right_corner"   },
+    { GLFW_RESIZE_NESW_CURSOR,   XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT, WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_SW_RESIZE,   "sw-resize",     "bottom_left_corner" },
+};
+
+// Finds the canonical entry for a GLFW standard cursor shape (edge == NONE).
+static const _GLFWcursorDesc* findCursorDescByShape(int glfwShape)
+{
+    for (size_t i = 0; i < sizeof(cursorTable) / sizeof(cursorTable[0]); i++)
+    {
+        if (cursorTable[i].glfwShape == glfwShape &&
+            cursorTable[i].resizeEdge == XDG_TOPLEVEL_RESIZE_EDGE_NONE)
+            return &cursorTable[i];
+    }
+    return NULL;
+}
+
+// Finds the directional entry for a specific resize edge.
+static const _GLFWcursorDesc* findCursorDescByEdge(uint32_t edge)
+{
+    for (size_t i = 0; i < sizeof(cursorTable) / sizeof(cursorTable[0]); i++)
+    {
+        if (cursorTable[i].resizeEdge == edge)
+            return &cursorTable[i];
+    }
+    return NULL;
+}
 
 static int createTmpfileCloexec(char* tmpname)
 {
@@ -334,41 +402,16 @@ static _GLFWcursorWayland lookupNamedCursor(const char* name, const char* fallba
     _GLFWcursorWayland cw = { NULL, NULL, NULL, 0, 0, 0, 0, 0 };
 
     cw.cursor = wl_cursor_theme_get_cursor(_glfw.wl.cursorTheme, name);
-    if (!cw.cursor && fallback)
+    if (!cw.cursor)
         cw.cursor = wl_cursor_theme_get_cursor(_glfw.wl.cursorTheme, fallback);
 
     if (_glfw.wl.cursorThemeHiDPI)
     {
         cw.cursorHiDPI = wl_cursor_theme_get_cursor(_glfw.wl.cursorThemeHiDPI, name);
-        if (!cw.cursorHiDPI && fallback)
+        if (!cw.cursorHiDPI)
             cw.cursorHiDPI = wl_cursor_theme_get_cursor(_glfw.wl.cursorThemeHiDPI, fallback);
     }
 
-    return cw;
-}
-
-static _GLFWcursorWayland lookupResizeEdgeCursor(uint32_t edge)
-{
-    const char* name = NULL;
-    const char* fallback = NULL;
-
-    switch (edge)
-    {
-        case XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT:     name = "nw-resize"; fallback = "top_left_corner";     break;
-        case XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT:    name = "ne-resize"; fallback = "top_right_corner";    break;
-        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT:  name = "sw-resize"; fallback = "bottom_left_corner";  break;
-        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT: name = "se-resize"; fallback = "bottom_right_corner"; break;
-        case XDG_TOPLEVEL_RESIZE_EDGE_TOP:          name = "n-resize";  fallback = "top_side";            break;
-        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM:       name = "s-resize";  fallback = "bottom_side";         break;
-        case XDG_TOPLEVEL_RESIZE_EDGE_LEFT:         name = "w-resize";  fallback = "left_side";           break;
-        case XDG_TOPLEVEL_RESIZE_EDGE_RIGHT:        name = "e-resize";  fallback = "right_side";          break;
-        default: break;
-    }
-
-    if (name)
-        return lookupNamedCursor(name, fallback);
-
-    _GLFWcursorWayland cw = { NULL, NULL, NULL, 0, 0, 0, 0, 0 };
     return cw;
 }
 
@@ -429,6 +472,25 @@ static uint32_t detectResizeEdge(_GLFWwindow* window, int x, int y)
     return XDG_TOPLEVEL_RESIZE_EDGE_NONE;
 }
 
+// Sets the cursor from a descriptor, preferring wp_cursor_shape_v1 when
+// available and falling back to wl_cursor_theme lookup.
+static void setDescCursor(_GLFWwindow* window, const _GLFWcursorDesc* desc)
+{
+    if (_glfw.wl.cursorShapeDevice)
+    {
+        wp_cursor_shape_device_v1_set_shape(
+            _glfw.wl.cursorShapeDevice,
+            _glfw.wl.pointerEnterSerial,
+            desc->shape);
+    }
+    else
+    {
+        _GLFWcursorWayland cw = lookupNamedCursor(desc->name, desc->fallback);
+        if (cw.cursor)
+            setCursorImage(window, &cw);
+    }
+}
+
 /* Anything that wants to change the cursor shape should call this. */
 static void applyCursor(_GLFWwindow* window)
 {
@@ -439,59 +501,66 @@ static void applyCursor(_GLFWwindow* window)
 
         if (pointerWindow == window)
         {
+            // Determine the resize edge (if any) for both main and
+            // fallback decoration surfaces
+            uint32_t edge = XDG_TOPLEVEL_RESIZE_EDGE_NONE;
+
             if (window->wl.surface == _glfw.wl.pointerSurface)
             {
-                // Main surface
-                if (window->cursorMode == GLFW_CURSOR_HIDDEN ||
-                    window->cursorMode == GLFW_CURSOR_DISABLED)
-                {
-                    wl_pointer_set_cursor(_glfw.wl.pointer,
-                                          _glfw.wl.pointerEnterSerial,
-                                          NULL, 0, 0);
-                }
-                else if (window->wl.resizeEdge != XDG_TOPLEVEL_RESIZE_EDGE_NONE)
-                {
-                    _GLFWcursorWayland cw = lookupResizeEdgeCursor(window->wl.resizeEdge);
-                    if (cw.cursor)
-                        setCursorImage(window, &cw);
-                }
-                else if (window->cursor)
-                {
-                    setCursorImage(window, &window->cursor->wl);
-                }
-                else
-                {
-                    _GLFWcursorWayland cw = lookupNamedCursor("left_ptr", NULL);
-                    if (cw.cursor)
-                        setCursorImage(window, &cw);
-                    else
-                        _glfwInputError(GLFW_PLATFORM_ERROR,
-                                        "Wayland: Standard cursor not found");
-                }
+                edge = window->wl.resizeEdge;
             }
-            else if (window->wl.fallback.decorations)
+            else if (window->wl.fallback.decorations && window->resizable)
             {
-                // Fallback decoration surface
-                // coordinates and reuse the same edge detection
                 int wx, wy;
-                uint32_t edge = XDG_TOPLEVEL_RESIZE_EDGE_NONE;
-                if (window->resizable &&
-                    fallbackToWindowCoords(window,
+                if (fallbackToWindowCoords(window,
                                            window->wl.fallback.pointerX,
                                            window->wl.fallback.pointerY,
                                            &wx, &wy))
                 {
                     edge = detectResizeEdge(window, wx, wy);
                 }
+            }
 
-                _GLFWcursorWayland cw;
-                if (edge != XDG_TOPLEVEL_RESIZE_EDGE_NONE)
-                    cw = lookupResizeEdgeCursor(edge);
+            // Hidden/disabled cursor
+            if (window->wl.surface == _glfw.wl.pointerSurface &&
+                (window->cursorMode == GLFW_CURSOR_HIDDEN ||
+                 window->cursorMode == GLFW_CURSOR_DISABLED))
+            {
+                wl_pointer_set_cursor(_glfw.wl.pointer,
+                                      _glfw.wl.pointerEnterSerial,
+                                      NULL, 0, 0);
+            }
+            // Resize edge cursor
+            else if (edge != XDG_TOPLEVEL_RESIZE_EDGE_NONE)
+            {
+                const _GLFWcursorDesc* desc = findCursorDescByEdge(edge);
+                if (desc)
+                    setDescCursor(window, desc);
+            }
+            // Application cursor (main surface only)
+            else if (window->wl.surface == _glfw.wl.pointerSurface &&
+                     window->cursor)
+            {
+                if (_glfw.wl.cursorShapeDevice &&
+                    window->cursor->wl.cursorShape)
+                {
+                    wp_cursor_shape_device_v1_set_shape(
+                        _glfw.wl.cursorShapeDevice,
+                        _glfw.wl.pointerEnterSerial,
+                        window->cursor->wl.cursorShape);
+                }
                 else
-                    cw = lookupNamedCursor("left_ptr", NULL);
-
-                if (cw.cursor)
-                    setCursorImage(window, &cw);
+                    setCursorImage(window, &window->cursor->wl);
+            }
+            // Default cursor
+            else
+            {
+                const _GLFWcursorDesc* desc = findCursorDescByShape(GLFW_ARROW_CURSOR);
+                if (desc)
+                    setDescCursor(window, desc);
+                else
+                    _glfwInputError(GLFW_PLATFORM_ERROR,
+                                    "Wayland: Standard cursor not found");
             }
         }
     }
@@ -2185,9 +2254,22 @@ static void seatHandleCapabilities(void* userData,
     {
         _glfw.wl.pointer = wl_seat_get_pointer(seat);
         wl_pointer_add_listener(_glfw.wl.pointer, &pointerListener, NULL);
+
+        if (_glfw.wl.cursorShapeManager)
+        {
+            _glfw.wl.cursorShapeDevice =
+                wp_cursor_shape_manager_v1_get_pointer(
+                    _glfw.wl.cursorShapeManager, _glfw.wl.pointer);
+        }
     }
     else if (!(caps & WL_SEAT_CAPABILITY_POINTER) && _glfw.wl.pointer)
     {
+        if (_glfw.wl.cursorShapeDevice)
+        {
+            wp_cursor_shape_device_v1_destroy(_glfw.wl.cursorShapeDevice);
+            _glfw.wl.cursorShapeDevice = NULL;
+        }
+
         if (wl_pointer_get_version(_glfw.wl.pointer) >= WL_POINTER_RELEASE_SINCE_VERSION)
             wl_pointer_release(_glfw.wl.pointer);
         else
@@ -3164,102 +3246,26 @@ GLFWbool _glfwCreateCursorWayland(_GLFWcursor* cursor,
 
 GLFWbool _glfwCreateStandardCursorWayland(_GLFWcursor* cursor, int shape)
 {
-    const char* name = NULL;
-
-    // Try the XDG names first
-    switch (shape)
+    const _GLFWcursorDesc* desc = findCursorDescByShape(shape);
+    if (!desc)
     {
-        case GLFW_ARROW_CURSOR:
-            name = "default";
-            break;
-        case GLFW_IBEAM_CURSOR:
-            name = "text";
-            break;
-        case GLFW_CROSSHAIR_CURSOR:
-            name = "crosshair";
-            break;
-        case GLFW_POINTING_HAND_CURSOR:
-            name = "pointer";
-            break;
-        case GLFW_RESIZE_EW_CURSOR:
-            name = "ew-resize";
-            break;
-        case GLFW_RESIZE_NS_CURSOR:
-            name = "ns-resize";
-            break;
-        case GLFW_RESIZE_NWSE_CURSOR:
-            name = "nwse-resize";
-            break;
-        case GLFW_RESIZE_NESW_CURSOR:
-            name = "nesw-resize";
-            break;
-        case GLFW_RESIZE_ALL_CURSOR:
-            name = "all-scroll";
-            break;
-        case GLFW_NOT_ALLOWED_CURSOR:
-            name = "not-allowed";
-            break;
+        _glfwInputError(GLFW_CURSOR_UNAVAILABLE,
+                        "Wayland: Standard cursor shape unavailable");
+        return GLFW_FALSE;
     }
 
-    cursor->wl.cursor = wl_cursor_theme_get_cursor(_glfw.wl.cursorTheme, name);
-
-    if (_glfw.wl.cursorThemeHiDPI)
+    _GLFWcursorWayland cw = lookupNamedCursor(desc->name, desc->fallback);
+    if (!cw.cursor)
     {
-        cursor->wl.cursorHiDPI =
-            wl_cursor_theme_get_cursor(_glfw.wl.cursorThemeHiDPI, name);
+        _glfwInputError(GLFW_CURSOR_UNAVAILABLE,
+                        "Wayland: Failed to create standard cursor \"%s\"",
+                        desc->name);
+        return GLFW_FALSE;
     }
 
-    if (!cursor->wl.cursor)
-    {
-        // Fall back to the core X11 names
-        switch (shape)
-        {
-            case GLFW_ARROW_CURSOR:
-                name = "left_ptr";
-                break;
-            case GLFW_IBEAM_CURSOR:
-                name = "xterm";
-                break;
-            case GLFW_CROSSHAIR_CURSOR:
-                name = "crosshair";
-                break;
-            case GLFW_POINTING_HAND_CURSOR:
-                name = "hand2";
-                break;
-            case GLFW_RESIZE_EW_CURSOR:
-                name = "sb_h_double_arrow";
-                break;
-            case GLFW_RESIZE_NS_CURSOR:
-                name = "sb_v_double_arrow";
-                break;
-            case GLFW_RESIZE_ALL_CURSOR:
-                name = "fleur";
-                break;
-            default:
-                _glfwInputError(GLFW_CURSOR_UNAVAILABLE,
-                                "Wayland: Standard cursor shape unavailable");
-                return GLFW_FALSE;
-        }
-
-        cursor->wl.cursor = wl_cursor_theme_get_cursor(_glfw.wl.cursorTheme, name);
-        if (!cursor->wl.cursor)
-        {
-            _glfwInputError(GLFW_CURSOR_UNAVAILABLE,
-                            "Wayland: Failed to create standard cursor \"%s\"",
-                            name);
-            return GLFW_FALSE;
-        }
-
-        if (_glfw.wl.cursorThemeHiDPI)
-        {
-            if (!cursor->wl.cursorHiDPI)
-            {
-                cursor->wl.cursorHiDPI =
-                    wl_cursor_theme_get_cursor(_glfw.wl.cursorThemeHiDPI, name);
-            }
-        }
-    }
-
+    cursor->wl.cursor = cw.cursor;
+    cursor->wl.cursorHiDPI = cw.cursorHiDPI;
+    cursor->wl.cursorShape = desc->shape;
     return GLFW_TRUE;
 }
 

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -1391,6 +1391,14 @@ static GLFWbool createXdgPopupShellObjects(_GLFWwindow* window,
     }
     xdg_popup_add_listener(window->wl.xdg.popup, &xdgPopupListener, window);
 
+    // Request a grab tied to the most recent pointer-button press. This is
+    // what makes the compositor auto-dismiss the popup (sending popup_done)
+    // on any outside click, app switch, etc. — matching native menu behavior.
+    // Must use a press serial; any other kind is undefined per the spec and
+    // strict compositors may reject or crash.
+    if (_glfw.wl.seat && _glfw.wl.pointerButtonSerial)
+        xdg_popup_grab(window->wl.xdg.popup, _glfw.wl.seat, _glfw.wl.pointerButtonSerial);
+
     wl_surface_commit(window->wl.surface);
     wl_display_roundtrip(_glfw.wl.display);
     return GLFW_TRUE;
@@ -1468,28 +1476,84 @@ static GLFWbool createXdgShellObjects(_GLFWwindow* window)
     return GLFW_TRUE;
 }
 
+static void issuePendingDragMove(_GLFWwindow* window)
+{
+    if (!window->wl.dragPending || !_glfw.wl.seat)
+        return;
+    window->wl.dragPending = GLFW_FALSE;
+
+    // If the user released the button while we were waiting for map, the
+    // stashed serial is stale — passing it to move is undefined per spec.
+    if (_glfw.wl.pointerButtonsDown <= 0)
+        return;
+
+    struct xdg_toplevel* toplevel = window->wl.xdg.toplevel;
+    if (!toplevel && window->wl.libdecor.frame)
+        toplevel = libdecor_frame_get_xdg_toplevel(window->wl.libdecor.frame);
+    if (!toplevel)
+        return;
+
+    xdg_toplevel_move(toplevel, _glfw.wl.seat, window->wl.dragPendingSerial);
+}
+
+static void mappedFrameHandleDone(void* userData,
+                                  struct wl_callback* callback,
+                                  uint32_t data)
+{
+    _GLFWwindow* window = userData;
+    wl_callback_destroy(callback);
+    window->wl.mappedCallback = NULL;
+    window->wl.mapped = GLFW_TRUE;
+
+    // A pending drag request queued before mapping fires now; the compositor
+    // has processed at least one buffer so xdg_toplevel.move is safe.
+    issuePendingDragMove(window);
+}
+
+static const struct wl_callback_listener mappedFrameListener =
+{
+    mappedFrameHandleDone
+};
+
+static void armMappedFrameCallback(_GLFWwindow* window)
+{
+    if (window->wl.mapped || window->wl.mappedCallback)
+        return;
+    window->wl.mappedCallback = wl_surface_frame(window->wl.surface);
+    if (window->wl.mappedCallback)
+    {
+        wl_callback_add_listener(window->wl.mappedCallback,
+                                 &mappedFrameListener, window);
+    }
+}
+
 static GLFWbool createShellObjects(_GLFWwindow* window)
 {
-    // Treat ImGui-style transient viewports as xdg_popups so they appear
-    // relative to the main window on Wayland (toplevel positioning is
-    // protocol-forbidden). The signal is `createdUnfocused` — ImGui's GLFW
-    // backend unconditionally sets GLFW_FOCUSED=false for viewport windows,
-    // whereas app-created toplevels (splash, main editor) leave the default
-    // `true`, so they stay as real toplevels.
-    if (window->wl.createdUnfocused && !window->decorated && !window->monitor)
+    // Opt into xdg_popup for windows the caller marked as menu-style via
+    // GLFW_FOCUS_ON_SHOW=false. Undecorated alone isn't enough — detached
+    // dockable viewports are also undecorated but should remain real
+    // toplevels so they can be moved by the compositor (xdg_toplevel.move)
+    // and participate in normal window stacking.
+    if (!window->focusOnShow && !window->decorated && !window->monitor)
     {
         _GLFWwindow* parent = findWaylandPopupParent(window);
         if (parent)
             return createXdgPopupShellObjects(window, parent);
     }
 
-    if (_glfw.wl.libdecor.context)
-    {
-        if (createLibdecorFrame(window))
-            return GLFW_TRUE;
-    }
+    GLFWbool ok;
+    if (_glfw.wl.libdecor.context && createLibdecorFrame(window))
+        ok = GLFW_TRUE;
+    else
+        ok = createXdgShellObjects(window);
 
-    return createXdgShellObjects(window);
+    // Register a one-shot frame callback so we learn when the compositor has
+    // first processed a buffer — our "truly mapped" signal. Any deferred
+    // drag-move waits for this before firing.
+    if (ok)
+        armMappedFrameCallback(window);
+
+    return ok;
 }
 
 static void destroyShellObjects(_GLFWwindow* window)
@@ -1511,12 +1575,18 @@ static void destroyShellObjects(_GLFWwindow* window)
     if (window->wl.xdg.surface)
         xdg_surface_destroy(window->wl.xdg.surface);
 
+    if (window->wl.mappedCallback)
+        wl_callback_destroy(window->wl.mappedCallback);
+
     window->wl.libdecor.frame = NULL;
     window->wl.xdg.decoration = NULL;
     window->wl.xdg.decorationMode = 0;
     window->wl.xdg.popup = NULL;
     window->wl.xdg.toplevel = NULL;
     window->wl.xdg.surface = NULL;
+    window->wl.mappedCallback = NULL;
+    window->wl.mapped = GLFW_FALSE;
+    window->wl.dragPending = GLFW_FALSE;
 }
 
 static GLFWbool createNativeSurface(_GLFWwindow* window,
@@ -2046,6 +2116,15 @@ static void pointerHandleButton(void* userData,
         return;
 
     _glfw.wl.serial = serial;
+    if (state == WL_POINTER_BUTTON_STATE_PRESSED)
+    {
+        _glfw.wl.pointerButtonSerial = serial;
+        _glfw.wl.pointerButtonsDown++;
+    }
+    else if (_glfw.wl.pointerButtonsDown > 0)
+    {
+        _glfw.wl.pointerButtonsDown--;
+    }
 
     const int button = buttonID - BTN_LEFT;
     const int action = (state == WL_POINTER_BUTTON_STATE_PRESSED);
@@ -2747,8 +2826,6 @@ GLFWbool _glfwCreateWindowWayland(_GLFWwindow* window,
                                   const _GLFWctxconfig* ctxconfig,
                                   const _GLFWfbconfig* fbconfig)
 {
-    window->wl.createdUnfocused = !wndconfig->focused;
-
     if (!createNativeSurface(window, wndconfig, fbconfig))
         return GLFW_FALSE;
 
@@ -2910,16 +2987,18 @@ void _glfwGetWindowPosWayland(_GLFWwindow* window, int* xpos, int* ypos)
 
 void _glfwSetWindowPosWayland(_GLFWwindow* window, int xpos, int ypos)
 {
-    if (!window->wl.xdg.surface && !window->wl.libdecor.frame)
-    {
-        window->wl.pendingPosX = xpos;
-        window->wl.pendingPosY = ypos;
-        window->wl.pendingPosSet = GLFW_TRUE;
-        return;
-    }
-
-    _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
-                    "Wayland: The platform does not support setting the window position after it has been mapped");
+    // Wayland has no global coordinate space, so we can't physically move a
+    // mapped toplevel. But we still mirror whatever the caller writes:
+    // ImGui's multi-viewport input-forwarding adds glfwGetWindowPos to each
+    // per-surface pointer coord to produce absolute coordinates, and its
+    // hit-testing assumes viewport->Pos matches that same value. The two
+    // drift together harmlessly as long as we always mirror the write;
+    // making one stable while the other isn't breaks widget clicks.
+    // Before mapping, this stashed value also feeds the xdg_popup
+    // positioner as the anchor-rect origin.
+    window->wl.pendingPosX = xpos;
+    window->wl.pendingPosY = ypos;
+    window->wl.pendingPosSet = GLFW_TRUE;
 }
 
 void _glfwGetWindowSizeWayland(_GLFWwindow* window, int* width, int* height)
@@ -3166,6 +3245,33 @@ void _glfwFocusWindowWayland(_GLFWwindow* window)
     }
 
     xdg_activation_token_v1_commit(window->wl.activationToken);
+}
+
+void _glfwDragWindowWayland(_GLFWwindow* window)
+{
+    if (!_glfw.wl.seat || !_glfw.wl.pointerButtonSerial)
+        return;
+
+    // Fire immediately when the toplevel is already mapped; otherwise stash
+    // the press serial and let the mapped-frame callback issue the move once
+    // the compositor has processed the first buffer. The pre-show case
+    // matters for tab-tear (caller invokes this before glfwShowWindow maps
+    // anything), and the pre-map case matters because calling
+    // xdg_toplevel.move on an unmapped surface crashes KWin.
+    if (!window->wl.mapped)
+    {
+        window->wl.dragPendingSerial = _glfw.wl.pointerButtonSerial;
+        window->wl.dragPending = GLFW_TRUE;
+        return;
+    }
+
+    struct xdg_toplevel* toplevel = window->wl.xdg.toplevel;
+    if (!toplevel && window->wl.libdecor.frame)
+        toplevel = libdecor_frame_get_xdg_toplevel(window->wl.libdecor.frame);
+    if (!toplevel)
+        return;
+
+    xdg_toplevel_move(toplevel, _glfw.wl.seat, _glfw.wl.pointerButtonSerial);
 }
 
 void _glfwSetWindowMonitorWayland(_GLFWwindow* window,

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -738,8 +738,11 @@ void _glfwUpdateBufferScaleFromOutputsWayland(_GLFWwindow* window)
     {
         window->wl.bufferScale = maxScale;
         wl_surface_set_buffer_scale(window->wl.surface, maxScale);
-        _glfwInputWindowContentScale(window, maxScale, maxScale);
         resizeFramebuffer(window);
+
+        float xscale, yscale;
+        _glfwGetWindowContentScaleWayland(window, &xscale, &yscale);
+        _glfwInputWindowContentScale(window, xscale, yscale);
 
         if (window->wl.visible)
             _glfwInputWindowDamage(window);
@@ -867,8 +870,11 @@ void fractionalScaleHandlePreferredScale(void* userData,
     _GLFWwindow* window = userData;
 
     window->wl.scalingNumerator = numerator;
-    _glfwInputWindowContentScale(window, numerator / 120.f, numerator / 120.f);
     resizeFramebuffer(window);
+
+    float xscale, yscale;
+    _glfwGetWindowContentScaleWayland(window, &xscale, &yscale);
+    _glfwInputWindowContentScale(window, xscale, yscale);
 
     // Update all monitors with the fractional scale so glfwGetMonitorContentScale
     // returns the accurate value instead of the integer wl_output scale.

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -55,10 +55,7 @@
 #include "xdg-toplevel-drag-v1-client-protocol.h"
 #include "fractional-scale-v1-client-protocol.h"
 
-// Mime type advertised by the wl_data_source we create for self-initiated
-// toplevel drags (see _glfwDragWindowWayland). No actual payload is
-// transferred — it's just a marker so the compositor will deliver
-// wl_data_device enter/motion/leave events to this client's surfaces.
+// Marker mime for self-initiated toplevel drags; no payload transferred.
 #define GLFW_WAYLAND_WINDOW_DRAG_MIME "application/x.glfw-window-drag"
 #include "cursor-shape-v1-client-protocol.h"
 
@@ -1209,10 +1206,7 @@ static GLFWbool createLibdecorFrame(_GLFWwindow* window)
         setIdleInhibitor(window, GLFW_FALSE);
     }
 
-    // Parent secondary libdecor toplevels to the first existing toplevel.
-    // See the matching comment in createXdgShellObjects. libdecor exposes the
-    // underlying xdg_toplevel via get_xdg_toplevel, so we set the parent on
-    // that directly.
+    // Same as createXdgShellObjects: parent secondary toplevels.
     if (window->wl.createdUnfocused && !window->monitor)
     {
         _GLFWwindow* parent = findWaylandPopupParent(window);
@@ -1281,9 +1275,7 @@ static void xdgPopupSurfaceHandleConfigure(void* userData,
                                            struct xdg_surface* surface,
                                            uint32_t serial)
 {
-    // Popups don't go through the toplevel state machine, so just ACK the
-    // configure and mark the window as visible. Size is already known from
-    // the positioner we handed to the compositor at creation.
+    // Popups skip the toplevel state machine; just ACK and mark visible.
     _GLFWwindow* window = userData;
     xdg_surface_ack_configure(surface, serial);
 
@@ -1304,8 +1296,7 @@ static void xdgPopupHandleConfigure(void* userData,
                                     int32_t x, int32_t y,
                                     int32_t width, int32_t height)
 {
-    // Compositor-confirmed popup geometry. Propagate surface-level size sync
-    // so the framebuffer stays in step with the compositor's view.
+    // Resize framebuffer to match compositor-confirmed popup geometry.
     _GLFWwindow* window = userData;
     if (width > 0 && height > 0 &&
         (width != window->wl.width || height != window->wl.height))
@@ -1319,9 +1310,7 @@ static void xdgPopupHandleConfigure(void* userData,
 
 static void xdgPopupHandlePopupDone(void* userData, struct xdg_popup* popup)
 {
-    // Compositor dismissed the popup (e.g. user clicked outside). Ask the
-    // owning application to close the window; it is responsible for
-    // teardown.
+    // Compositor dismissed the popup (e.g. outside click).
     _GLFWwindow* window = userData;
     _glfwInputWindowCloseRequest(window);
 }
@@ -1394,9 +1383,7 @@ static GLFWbool createXdgPopupShellObjects(_GLFWwindow* window,
     const int h = window->wl.height > 0 ? window->wl.height : 1;
     xdg_positioner_set_size(positioner, w, h);
 
-    // Treat the coords handed to glfwSetWindowPos as parent-relative, because
-    // on Wayland there is no global coordinate space. Callers are expected
-    // to supply coordinates in the parent window's local frame.
+    // pendingPos is parent-relative (no global coords on Wayland).
     const int px = window->wl.pendingPosSet ? window->wl.pendingPosX : 0;
     const int py = window->wl.pendingPosSet ? window->wl.pendingPosY : 0;
     xdg_positioner_set_anchor_rect(positioner, px, py, 1, 1);
@@ -1421,11 +1408,7 @@ static GLFWbool createXdgPopupShellObjects(_GLFWwindow* window,
     }
     xdg_popup_add_listener(window->wl.xdg.popup, &xdgPopupListener, window);
 
-    // Request a grab tied to the most recent pointer-button press. This is
-    // what makes the compositor auto-dismiss the popup (sending popup_done)
-    // on any outside click, app switch, etc. — matching native menu behavior.
-    // Must use a press serial; any other kind is undefined per the spec and
-    // strict compositors may reject or crash.
+    // Grab with a press serial so the compositor auto-dismisses on outside click.
     if (_glfw.wl.seat && _glfw.wl.pointerButtonSerial)
         xdg_popup_grab(window->wl.xdg.popup, _glfw.wl.seat, _glfw.wl.pointerButtonSerial);
 
@@ -1462,12 +1445,8 @@ static GLFWbool createXdgShellObjects(_GLFWwindow* window)
 
     xdg_toplevel_set_title(window->wl.xdg.toplevel, window->title);
 
-    // Parent secondary toplevels (created with GLFW_FOCUSED=false) to the
-    // first existing application toplevel so the compositor keeps them
-    // logically grouped. Concretely, during a DnD-based drag
-    // (xdg_toplevel_drag_v1), the compositor typically raises the hovered
-    // window's app to the front; without set_parent, the primary window
-    // gets left behind when the cursor passes over other apps.
+    // Parent secondary toplevels so the compositor keeps them grouped
+    // (prevents the main window from getting buried during drags).
     if (window->wl.createdUnfocused && !window->monitor)
     {
         _GLFWwindow* parent = findWaylandPopupParent(window);
@@ -1533,8 +1512,7 @@ static void issuePendingDragMove(_GLFWwindow* window)
         return;
     window->wl.dragPending = GLFW_FALSE;
 
-    // If the user released the button while we were waiting for map, the
-    // stashed serial is stale — passing it to move is undefined per spec.
+    // Button was released while waiting for map; serial is stale.
     if (_glfw.wl.pointerButtonsDown <= 0)
         return;
 
@@ -1564,8 +1542,7 @@ static void mappedFrameHandleDone(void* userData,
     window->wl.mappedCallback = NULL;
     window->wl.mapped = GLFW_TRUE;
 
-    // A pending drag request queued before mapping fires now; the compositor
-    // has processed at least one buffer so xdg_toplevel.move is safe.
+    // Now that the surface is mapped, fire any deferred drag request.
     issuePendingDragMove(window);
 }
 
@@ -1588,11 +1565,7 @@ static void armMappedFrameCallback(_GLFWwindow* window)
 
 static GLFWbool createShellObjects(_GLFWwindow* window)
 {
-    // Opt into xdg_popup for windows the caller marked as menu-style via
-    // GLFW_FOCUS_ON_SHOW=false. Undecorated alone isn't enough — other
-    // secondary toplevels may also be undecorated but should remain real
-    // toplevels so they can be moved by the compositor (xdg_toplevel.move)
-    // and participate in normal window stacking.
+    // Menu-style windows (undecorated + !focusOnShow) become xdg_popups.
     if (!window->focusOnShow && !window->decorated && !window->monitor)
     {
         _GLFWwindow* parent = findWaylandPopupParent(window);
@@ -1606,9 +1579,7 @@ static GLFWbool createShellObjects(_GLFWwindow* window)
     else
         ok = createXdgShellObjects(window);
 
-    // Register a one-shot frame callback so we learn when the compositor has
-    // first processed a buffer — our "truly mapped" signal. Any deferred
-    // drag-move waits for this before firing.
+    // Deferred drag-moves wait for this "truly mapped" signal.
     if (ok)
         armMappedFrameCallback(window);
 
@@ -1973,10 +1944,8 @@ static void processPointerLeaveSurface(struct wl_surface* surface)
     if (window->wl.surface == surface)
     {
         window->wl.resizeEdge = XDG_TOPLEVEL_RESIZE_EDGE_NONE;
-        // During a toplevel drag session, the compositor steals the pointer
-        // for DnD. Suppress the cursor-leave notification so the application
-        // doesn't park the cursor at FLT_MAX and lose hover state. DnD
-        // enter/motion events provide cursor position while the drag is live.
+        // Suppress cursor-leave during toplevel drag so the app doesn't
+        // park the cursor at FLT_MAX. Drag-and-drop events provide position instead.
         if (!_glfw.wl.toplevelDragSession.source)
             _glfwInputCursorEnter(window, GLFW_FALSE);
     }
@@ -2027,10 +1996,8 @@ static void processPointerMotion(double xpos, double ypos)
 
 static void processPointerButton(int button, int action)
 {
-    // When a toplevel drag session is active, the compositor sends a button
-    // release as it transfers the implicit grab to the DnD session. Suppress
-    // it so the application's input state keeps the button held throughout
-    // the drag. endToplevelDragSession synthesizes the release when done.
+    // Compositor sends a spurious release when transferring the grab to drag-and-drop.
+    // Suppress it; endToplevelDragSession synthesizes the real release.
     if (_glfw.wl.toplevelDragSession.source &&
         button == GLFW_MOUSE_BUTTON_LEFT && action == GLFW_RELEASE)
     {
@@ -2191,9 +2158,8 @@ static void pointerHandleButton(void* userData,
 
     _glfw.wl.serial = serial;
 
-    // Suppress the button release the compositor sends when transferring the
-    // implicit grab to the DnD session. Without this, pointerButtonsDown drops
-    // to 0 and downstream logic thinks no button is held during the drag.
+    // Suppress the spurious release the compositor sends when transferring
+    // the implicit grab to the drag-and-drop session.
     const int btnIdx = buttonID - BTN_LEFT;
     if (_glfw.wl.toplevelDragSession.source &&
         btnIdx == GLFW_MOUSE_BUTTON_LEFT &&
@@ -2478,12 +2444,8 @@ static void keyboardHandleLeave(void* userData,
     _glfw.wl.serial = serial;
     _glfw.wl.keyboardFocus = NULL;
 
-    // On Wayland, keyboard focus follows the pointer. Creating a new window
-    // under the cursor triggers wl_keyboard.leave on the old window, and
-    // _glfwInputWindowFocus synthesizes button releases for all held buttons.
-    // This is wrong when the physical button is still held (e.g. mid-drag
-    // tab tear-out). Temporarily mark buttons as released so
-    // _glfwInputWindowFocus's loop has nothing to release, then restore them.
+    // _glfwInputWindowFocus synthesizes button releases, but during a drag
+    // the physical button is still held. Hide button state across the call.
     if (_glfw.wl.pointerButtonsDown > 0)
     {
         GLFWbool savedButtons[GLFW_MOUSE_BUTTON_LAST + 1];
@@ -2826,14 +2788,8 @@ static void dataDeviceHandleEnter(void* userData,
 static void dataDeviceHandleLeave(void* userData,
                                   struct wl_data_device* device)
 {
-    // During our own toplevel drag, park the reported cursor position far
-    // off-screen while the cursor is outside all of our surfaces. The value
-    // is chosen to be large-negative but not close to float limits, so
-    // applications that treat extreme positions as "invalid" (and would
-    // tear down drag state) see it as valid-but-nowhere, letting the drag
-    // stay live and tracking resume on re-entry. Also invalidate the cached
-    // virtual pos so the next enter's _glfwInputCursorPos doesn't early-out
-    // on a coord match.
+    // Park cursor off-screen during drag leave so the app keeps the drag
+    // alive. Invalidate virtualCursorPos so the next enter isn't deduped.
     if (_glfw.wl.toplevelDragSession.source && _glfw.wl.dragFocus)
     {
         _GLFWwindow* focus = _glfw.wl.dragFocus;
@@ -2856,10 +2812,7 @@ static void dataDeviceHandleMotion(void* userData,
                                    wl_fixed_t x,
                                    wl_fixed_t y)
 {
-    // During our own toplevel drag, the compositor captures pointer input,
-    // so wl_pointer.motion never fires. Forward the DnD motion as a cursor
-    // move so the client sees the drag passing over its surfaces and can
-    // drive drop-target hit-testing.
+    // wl_pointer.motion is captured during drag-and-drop; forward as cursor events.
     if (_glfw.wl.dragFocus && _glfw.wl.toplevelDragSession.source)
     {
         const double xpos = wl_fixed_to_double(x);
@@ -2891,11 +2844,8 @@ static void dataDeviceHandleDrop(void* userData,
     if (!_glfw.wl.dragOffer)
         return;
 
-    // For a self-initiated toplevel drag we have no payload to transfer; just
-    // finish the offer so the compositor completes the drag protocol and
-    // dnd_finished fires on the source. Without this the compositor keeps
-    // the drag in a half-completed state and normal pointer input stays
-    // routed to DnD handlers instead of returning to the application.
+    // No payload for our own toplevel drag; just complete the protocol so
+    // the compositor stops routing input to drag-and-drop handlers.
     if (_glfw.wl.toplevelDragSession.source)
     {
         // wl_data_offer.finish and set_actions are v3+. Calling either on
@@ -3119,11 +3069,8 @@ GLFWbool _glfwCreateWindowWayland(_GLFWwindow* window,
 
 void _glfwDestroyWindowWayland(_GLFWwindow* window)
 {
-    // If any drag-session state pointed at this window, clear it now.
-    // Otherwise end-of-drag callbacks (endToplevelDragSession, DnD motion
-    // forwarding) would try to synthesize input events on the freed window
-    // — which can happen when the application destroys an OS window while
-    // the compositor still holds a drag open on it.
+    // Detach from any active drag session so end-of-drag callbacks don't
+    // touch a freed window.
     if (_glfw.wl.toplevelDragSession.window == window)
         _glfw.wl.toplevelDragSession.window = NULL;
     if (_glfw.wl.dragFocus == window)
@@ -3205,12 +3152,7 @@ void _glfwSetWindowIconWayland(_GLFWwindow* window,
 
 void _glfwGetWindowPosWayland(_GLFWwindow* window, int* xpos, int* ypos)
 {
-    // A Wayland client is not aware of its global position. For popup windows
-    // we do know the requested parent-relative anchor we were created at, so
-    // report that; for toplevels, there's no meaningful value to return.
-    //
-    // Stay silent: applications often poll this every frame and a warning
-    // would flood the log.
+    // Popups have a parent-relative position; toplevels don't.
     if (window->wl.pendingPosSet)
     {
         if (xpos) *xpos = window->wl.pendingPosX;
@@ -3220,12 +3162,8 @@ void _glfwGetWindowPosWayland(_GLFWwindow* window, int* xpos, int* ypos)
 
 void _glfwSetWindowPosWayland(_GLFWwindow* window, int xpos, int ypos)
 {
-    // Wayland has no global coordinate space, so we can't physically move a
-    // mapped toplevel. But we still mirror whatever the caller writes so
-    // later glfwGetWindowPos returns what was last set — callers that use
-    // the stored position to translate per-surface pointer coordinates
-    // rely on write/read consistency. Before mapping, this stashed value
-    // also feeds the xdg_popup positioner as the anchor-rect origin.
+    // Can't move a mapped toplevel on Wayland, but callers rely on
+    // write/read consistency. Also used as the xdg_popup anchor origin.
     window->wl.pendingPosX = xpos;
     window->wl.pendingPosY = ypos;
     window->wl.pendingPosSet = GLFW_TRUE;
@@ -3493,15 +3431,10 @@ static void endToplevelDragSession(void)
     }
     _glfw.wl.toplevelDragSession.window = NULL;
 
-    // Also decrement the counter since the real wl_pointer.button release was
-    // consumed by the compositor for the drag. Keeping it above zero would
-    // wrongly suggest a button is still held for future logic (deferred move
-    // gates, drag trigger heuristics, ...).
+    // The compositor consumed the real release; account for it and synthesize
+    // one so the application sees "drag ended".
     if (_glfw.wl.pointerButtonsDown > 0)
         _glfw.wl.pointerButtonsDown--;
-
-    // Synthesize the swallowed left-button release so the application's
-    // input pipeline gets to see "drag ended" and can run any drop logic.
     if (window)
         _glfwInputMouseClick(window, GLFW_MOUSE_BUTTON_LEFT, GLFW_RELEASE, 0);
 }
@@ -3528,11 +3461,8 @@ static void dragSourceHandleCancelled(void* data, struct wl_data_source* source)
 static void dragSourceHandleDndDropPerformed(void* data, struct wl_data_source* source)
 {
     (void)data; (void)source;
-    // The user released. Clean up here rather than waiting for
-    // dnd_finished: the latter only fires if a target actually called
-    // wl_data_offer_finish, which we can't guarantee when the drop lands
-    // on a foreign client. endToplevelDragSession is idempotent (clears
-    // its own state) so a later dnd_finished is a safe no-op.
+    // Clean up immediately; dnd_finished may not fire if the drop landed
+    // on a foreign client. endToplevelDragSession is idempotent.
     endToplevelDragSession();
 }
 
@@ -3555,12 +3485,8 @@ static const struct wl_data_source_listener dragSourceListener =
     dragSourceHandleAction,
 };
 
-// Start a self-initiated toplevel drag using xdg_toplevel_drag_v1. Returns
-// GLFW_TRUE on success; caller should fall back to xdg_toplevel.move otherwise.
-// The critical property of this path vs plain move: the compositor delivers
-// wl_data_device enter/motion/leave events to our surfaces under the cursor,
-// so the application can detect drop targets while the dragged window
-// follows the cursor.
+// Start a toplevel drag via xdg_toplevel_drag_v1 so the compositor delivers
+// drag-and-drop events for drop-target hit-testing. Falls back to xdg_toplevel.move.
 static GLFWbool startToplevelDragSession(_GLFWwindow* window, uint32_t serial)
 {
     if (!_glfw.wl.toplevelDragManager ||
@@ -3587,9 +3513,8 @@ static GLFWbool startToplevelDragSession(_GLFWwindow* window, uint32_t serial)
     wl_data_source_add_listener(source, &dragSourceListener, NULL);
     wl_data_source_offer(source, GLFW_WAYLAND_WINDOW_DRAG_MIME);
 
-    // Advertise "move" as the DnD action. Without negotiated actions the
-    // compositor (on v3+) won't deliver dnd_drop_performed / dnd_finished,
-    // leaving the drag in a half-completed state after the user releases.
+    // Without a negotiated action, v3+ compositors won't deliver
+    // dnd_drop_performed / dnd_finished.
     if (wl_data_source_get_version(source) >= 3)
     {
         wl_data_source_set_actions(source,
@@ -3609,24 +3534,10 @@ static GLFWbool startToplevelDragSession(_GLFWwindow* window, uint32_t serial)
     _glfw.wl.toplevelDragSession.drag = drag;
     _glfw.wl.toplevelDragSession.window = window;
 
-    // Per spec, when the dragged toplevel is already mapped (our case, since
-    // we only reach here after the window is mapped) attach() must come
-    // before start_drag(). The offset hints where the cursor hotspot should
-    // sit relative to the toplevel's top-left in surface-local coords —
-    // passing (0, 0) snaps the window so the cursor is in its top-left
-    // corner.
-    //
-    // Compute where the cursor sits relative to the toplevel's top-left.
-    //
-    // Two cases:
-    //  - Same-window drag (regular titlebar drag): use the window's own
-    //    tracked cursor position — it's current and surface-local.
-    //  - Cross-window drag (tab tear-out): the press happened on a
-    //    different surface (main window's tab bar), a new toplevel was
-    //    created under the cursor, and its pendingPos was set from the
-    //    CURRENT cursor minus ImGui's click offset. Use the origin
-    //    window's live cursor (not the press-time capture) so the
-    //    compositor attachment offset matches ImGui's click offset.
+    // attach() must precede start_drag() for already-mapped toplevels.
+    // The offset is where the cursor sits relative to the window's
+    // top-left. For cross-window drags (tab tear-out), use the origin
+    // window's live cursor so the offset matches ImGui's click offset.
     double rawOffsetX, rawOffsetY;
     if (_glfw.wl.pointerButtonSurface == window->wl.surface)
     {
@@ -3661,21 +3572,14 @@ void _glfwDragWindowWayland(_GLFWwindow* window)
     if (!_glfw.wl.seat || !_glfw.wl.pointerButtonSerial)
         return;
 
-    // A drag session is already in flight for this window — no-op. Callers
-    // may invoke this every frame during their own drag math, but we only
-    // want to hand the drag to the compositor once per user press.
+    // Already dragging this window.
     if (_glfw.wl.toplevelDragSession.source &&
         _glfw.wl.toplevelDragSession.window == window)
     {
         return;
     }
 
-    // Pre-map: stash the request and let the mapped-frame callback fire it
-    // once the compositor has processed the first buffer. Calling
-    // xdg_toplevel.move (or starting a drag attached to an unmapped toplevel)
-    // on an unmapped surface has been observed to crash KWin. This matters
-    // for callers that invoke glfwDragWindow on a window they just created
-    // but haven't yet shown.
+    // Defer until mapped; dragging an unmapped surface crashes KWin.
     if (!window->wl.mapped)
     {
         window->wl.dragPendingSerial = _glfw.wl.pointerButtonSerial;
@@ -3683,10 +3587,7 @@ void _glfwDragWindowWayland(_GLFWwindow* window)
         return;
     }
 
-    // Preferred path: xdg_toplevel_drag_v1 (staging) — same visual effect as
-    // xdg_toplevel.move but the compositor keeps delivering DnD events to
-    // our surfaces under the cursor, so the application can hit-test the
-    // dragged window against drop targets.
+    // Preferred: xdg_toplevel_drag_v1 delivers drag-and-drop events for hit-testing.
     if (startToplevelDragSession(window, _glfw.wl.pointerButtonSerial))
         return;
 
@@ -3699,9 +3600,7 @@ void _glfwDragWindowWayland(_GLFWwindow* window)
 
     xdg_toplevel_move(toplevel, _glfw.wl.seat, _glfw.wl.pointerButtonSerial);
 
-    // xdg_toplevel.move swallows the release event, so synthesize one now so
-    // the application's input state doesn't stay stuck in "button held" after
-    // the move ends.
+    // xdg_toplevel.move swallows the release; synthesize one.
     if (_glfw.wl.pointerButtonsDown > 0)
         _glfw.wl.pointerButtonsDown--;
     _glfwInputMouseClick(window, GLFW_MOUSE_BUTTON_LEFT, GLFW_RELEASE, 0);

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -870,6 +870,11 @@ void fractionalScaleHandlePreferredScale(void* userData,
     _glfwInputWindowContentScale(window, numerator / 120.f, numerator / 120.f);
     resizeFramebuffer(window);
 
+    // Update all monitors with the fractional scale so glfwGetMonitorContentScale
+    // returns the accurate value instead of the integer wl_output scale.
+    for (int i = 0; i < _glfw.monitorCount; i++)
+        _glfw.monitors[i]->wl.fractionalScaleNumerator = numerator;
+
     if (window->wl.visible)
         _glfwInputWindowDamage(window);
 }

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -284,88 +284,219 @@ static void destroyFallbackDecorations(_GLFWwindow* window)
     destroyFallbackEdge(&window->wl.fallback.bottom);
 }
 
-static void setNamedCursor(_GLFWwindow* window, const char* cursorName)
+static void setCursorImage(_GLFWwindow* window, _GLFWcursorWayland* cursorWayland)
 {
+    struct itimerspec timer = {0};
+    struct wl_cursor* wlCursor = cursorWayland->cursor;
+    struct wl_cursor_image* image;
+    struct wl_buffer* buffer;
     struct wl_surface* surface = _glfw.wl.cursorSurface;
-    struct wl_cursor_theme* theme = _glfw.wl.cursorTheme;
     int scale = 1;
 
-    if (window->wl.bufferScale > 1 && _glfw.wl.cursorThemeHiDPI)
+    if (!wlCursor)
+        buffer = cursorWayland->buffer;
+    else
     {
-        // We only support up to scale=2 for now, since libwayland-cursor
-        // requires us to load a different theme for each size.
-        scale = 2;
-        theme = _glfw.wl.cursorThemeHiDPI;
+        if (window->wl.bufferScale > 1 && cursorWayland->cursorHiDPI)
+        {
+            wlCursor = cursorWayland->cursorHiDPI;
+            scale = 2;
+        }
+
+        image = wlCursor->images[cursorWayland->currentImage];
+        buffer = wl_cursor_image_get_buffer(image);
+        if (!buffer)
+            return;
+
+        timer.it_value.tv_sec = image->delay / 1000;
+        timer.it_value.tv_nsec = (image->delay % 1000) * 1000000;
+        timerfd_settime(_glfw.wl.cursorTimerfd, 0, &timer, NULL);
+
+        cursorWayland->width = image->width;
+        cursorWayland->height = image->height;
+        cursorWayland->xhot = image->hotspot_x;
+        cursorWayland->yhot = image->hotspot_y;
     }
-
-    struct wl_cursor* cursor = wl_cursor_theme_get_cursor(theme, cursorName);
-    if (!cursor)
-        return;
-
-    // TODO: handle animated cursors too.
-    struct wl_cursor_image* image = cursor->images[0];
-    if (!image)
-        return;
-
-    struct wl_buffer* buffer = wl_cursor_image_get_buffer(image);
-    if (!buffer)
-        return;
 
     wl_pointer_set_cursor(_glfw.wl.pointer, _glfw.wl.pointerEnterSerial,
                           surface,
-                          image->hotspot_x / scale,
-                          image->hotspot_y / scale);
+                          cursorWayland->xhot / scale,
+                          cursorWayland->yhot / scale);
     wl_surface_set_buffer_scale(surface, scale);
     wl_surface_attach(surface, buffer, 0, 0);
-    wl_surface_damage(surface, 0, 0, image->width, image->height);
+    wl_surface_damage(surface, 0, 0,
+                      cursorWayland->width, cursorWayland->height);
     wl_surface_commit(surface);
 }
 
-static void updateFallbackDecorationCursor(_GLFWwindow* window, double xpos, double ypos)
+static _GLFWcursorWayland lookupNamedCursor(const char* name, const char* fallback)
 {
-    window->wl.fallback.pointerX = xpos;
-    window->wl.fallback.pointerY = ypos;
+    _GLFWcursorWayland cw = { NULL, NULL, NULL, 0, 0, 0, 0, 0 };
 
-    const char* cursorName = "left_ptr";
+    cw.cursor = wl_cursor_theme_get_cursor(_glfw.wl.cursorTheme, name);
+    if (!cw.cursor && fallback)
+        cw.cursor = wl_cursor_theme_get_cursor(_glfw.wl.cursorTheme, fallback);
 
-    if (window->resizable)
+    if (_glfw.wl.cursorThemeHiDPI)
     {
-        if (_glfw.wl.pointerSurface == window->wl.fallback.top.surface)
-        {
-            if (ypos < GLFW_BORDER_SIZE)
-                cursorName = "n-resize";
-        }
-        else if (_glfw.wl.pointerSurface == window->wl.fallback.left.surface)
-        {
-            if (ypos < GLFW_BORDER_SIZE)
-                cursorName = "nw-resize";
-            else
-                cursorName = "w-resize";
-        }
-        else if (_glfw.wl.pointerSurface == window->wl.fallback.right.surface)
-        {
-            if (ypos < GLFW_BORDER_SIZE)
-                cursorName = "ne-resize";
-            else
-                cursorName = "e-resize";
-        }
-        else if (_glfw.wl.pointerSurface == window->wl.fallback.bottom.surface)
-        {
-            if (xpos < GLFW_BORDER_SIZE)
-                cursorName = "sw-resize";
-            else if (xpos > window->wl.width + GLFW_BORDER_SIZE)
-                cursorName = "se-resize";
-            else
-                cursorName = "s-resize";
-        }
+        cw.cursorHiDPI = wl_cursor_theme_get_cursor(_glfw.wl.cursorThemeHiDPI, name);
+        if (!cw.cursorHiDPI && fallback)
+            cw.cursorHiDPI = wl_cursor_theme_get_cursor(_glfw.wl.cursorThemeHiDPI, fallback);
     }
 
-    if (window->wl.fallback.cursorName != cursorName)
+    return cw;
+}
+
+static _GLFWcursorWayland lookupResizeEdgeCursor(uint32_t edge)
+{
+    const char* name = NULL;
+    const char* fallback = NULL;
+
+    switch (edge)
     {
-        setNamedCursor(window, cursorName);
-        window->wl.fallback.cursorName = cursorName;
+        case XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT:     name = "nw-resize"; fallback = "top_left_corner";     break;
+        case XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT:    name = "ne-resize"; fallback = "top_right_corner";    break;
+        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT:  name = "sw-resize"; fallback = "bottom_left_corner";  break;
+        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT: name = "se-resize"; fallback = "bottom_right_corner"; break;
+        case XDG_TOPLEVEL_RESIZE_EDGE_TOP:          name = "n-resize";  fallback = "top_side";            break;
+        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM:       name = "s-resize";  fallback = "bottom_side";         break;
+        case XDG_TOPLEVEL_RESIZE_EDGE_LEFT:         name = "w-resize";  fallback = "left_side";           break;
+        case XDG_TOPLEVEL_RESIZE_EDGE_RIGHT:        name = "e-resize";  fallback = "right_side";          break;
+        default: break;
+    }
+
+    if (name)
+        return lookupNamedCursor(name, fallback);
+
+    _GLFWcursorWayland cw = { NULL, NULL, NULL, 0, 0, 0, 0, 0 };
+    return cw;
+}
+
+// Translates fallback decoration subsurface-local coordinates to
+// main window coordinates so detectResizeEdge can handle both paths.
+static GLFWbool fallbackToWindowCoords(_GLFWwindow* window,
+                                       double sx, double sy,
+                                       int* wx, int* wy)
+{
+    if (_glfw.wl.pointerSurface == window->wl.fallback.top.surface)
+    {
+        *wx = (int) sx;
+        *wy = (int) sy - GLFW_CAPTION_HEIGHT;
+    }
+    else if (_glfw.wl.pointerSurface == window->wl.fallback.left.surface)
+    {
+        *wx = (int) sx - GLFW_BORDER_SIZE;
+        *wy = (int) sy - GLFW_CAPTION_HEIGHT;
+    }
+    else if (_glfw.wl.pointerSurface == window->wl.fallback.right.surface)
+    {
+        *wx = (int) sx + window->wl.width;
+        *wy = (int) sy - GLFW_CAPTION_HEIGHT;
+    }
+    else if (_glfw.wl.pointerSurface == window->wl.fallback.bottom.surface)
+    {
+        *wx = (int) sx - GLFW_BORDER_SIZE;
+        *wy = (int) sy + window->wl.height;
+    }
+    else
+        return GLFW_FALSE;
+
+    return GLFW_TRUE;
+}
+
+static uint32_t detectResizeEdge(_GLFWwindow* window, int x, int y)
+{
+    const int w = window->wl.width;
+    const int h = window->wl.height;
+    // Note that this is not the same as GLFW_BORDER_SIZE, because undecorated windows need a bigger
+    // hit zone than decorated ones, where a resize can be started from slightly outside the window.
+    const int border = 8;
+
+    const GLFWbool onLeft   = (x < border);
+    const GLFWbool onRight  = (x >= w - border);
+    const GLFWbool onTop    = (y < border);
+    const GLFWbool onBottom = (y >= h - border);
+
+    if      (onTop    && onLeft)  return XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT;
+    else if (onTop    && onRight) return XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT;
+    else if (onBottom && onLeft)  return XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT;
+    else if (onBottom && onRight) return XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT;
+    else if (onTop)               return XDG_TOPLEVEL_RESIZE_EDGE_TOP;
+    else if (onBottom)            return XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM;
+    else if (onLeft)              return XDG_TOPLEVEL_RESIZE_EDGE_LEFT;
+    else if (onRight)             return XDG_TOPLEVEL_RESIZE_EDGE_RIGHT;
+
+    return XDG_TOPLEVEL_RESIZE_EDGE_NONE;
+}
+
+/* Anything that wants to change the cursor shape should call this. */
+static void applyCursor(_GLFWwindow* window)
+{
+    if (_glfw.wl.pointer && _glfw.wl.pointerSurface)
+    {
+        _GLFWwindow* pointerWindow =
+            wl_surface_get_user_data(_glfw.wl.pointerSurface);
+
+        if (pointerWindow == window)
+        {
+            if (window->wl.surface == _glfw.wl.pointerSurface)
+            {
+                // Main surface
+                if (window->cursorMode == GLFW_CURSOR_HIDDEN ||
+                    window->cursorMode == GLFW_CURSOR_DISABLED)
+                {
+                    wl_pointer_set_cursor(_glfw.wl.pointer,
+                                          _glfw.wl.pointerEnterSerial,
+                                          NULL, 0, 0);
+                }
+                else if (window->wl.resizeEdge != XDG_TOPLEVEL_RESIZE_EDGE_NONE)
+                {
+                    _GLFWcursorWayland cw = lookupResizeEdgeCursor(window->wl.resizeEdge);
+                    if (cw.cursor)
+                        setCursorImage(window, &cw);
+                }
+                else if (window->cursor)
+                {
+                    setCursorImage(window, &window->cursor->wl);
+                }
+                else
+                {
+                    _GLFWcursorWayland cw = lookupNamedCursor("left_ptr", NULL);
+                    if (cw.cursor)
+                        setCursorImage(window, &cw);
+                    else
+                        _glfwInputError(GLFW_PLATFORM_ERROR,
+                                        "Wayland: Standard cursor not found");
+                }
+            }
+            else if (window->wl.fallback.decorations)
+            {
+                // Fallback decoration surface
+                // coordinates and reuse the same edge detection
+                int wx, wy;
+                uint32_t edge = XDG_TOPLEVEL_RESIZE_EDGE_NONE;
+                if (window->resizable &&
+                    fallbackToWindowCoords(window,
+                                           window->wl.fallback.pointerX,
+                                           window->wl.fallback.pointerY,
+                                           &wx, &wy))
+                {
+                    edge = detectResizeEdge(window, wx, wy);
+                }
+
+                _GLFWcursorWayland cw;
+                if (edge != XDG_TOPLEVEL_RESIZE_EDGE_NONE)
+                    cw = lookupResizeEdgeCursor(edge);
+                else
+                    cw = lookupNamedCursor("left_ptr", NULL);
+
+                if (cw.cursor)
+                    setCursorImage(window, &cw);
+            }
+        }
     }
 }
+
 
 static void handleFallbackDecorationButton(_GLFWwindow* window, int button, int action)
 {
@@ -378,41 +509,18 @@ static void handleFallbackDecorationButton(_GLFWwindow* window, int button, int 
 
     if (button == GLFW_MOUSE_BUTTON_LEFT)
     {
+        int wx, wy;
         uint32_t edges = XDG_TOPLEVEL_RESIZE_EDGE_NONE;
-
-        if (_glfw.wl.pointerSurface == window->wl.fallback.top.surface)
+        if (window->resizable &&
+            fallbackToWindowCoords(window, xpos, ypos, &wx, &wy))
         {
-            if (ypos < GLFW_BORDER_SIZE)
-                edges = XDG_TOPLEVEL_RESIZE_EDGE_TOP;
-            else
-                xdg_toplevel_move(window->wl.xdg.toplevel, _glfw.wl.seat, serial);
-        }
-        else if (_glfw.wl.pointerSurface == window->wl.fallback.left.surface)
-        {
-            if (ypos < GLFW_BORDER_SIZE)
-                edges = XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT;
-            else
-                edges = XDG_TOPLEVEL_RESIZE_EDGE_LEFT;
-        }
-        else if (_glfw.wl.pointerSurface == window->wl.fallback.right.surface)
-        {
-            if (ypos < GLFW_BORDER_SIZE)
-                edges = XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT;
-            else
-                edges = XDG_TOPLEVEL_RESIZE_EDGE_RIGHT;
-        }
-        else if (_glfw.wl.pointerSurface == window->wl.fallback.bottom.surface)
-        {
-            if (xpos < GLFW_BORDER_SIZE)
-                edges = XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT;
-            else if (xpos > window->wl.width + GLFW_BORDER_SIZE)
-                edges = XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT;
-            else
-                edges = XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM;
+            edges = detectResizeEdge(window, wx, wy);
         }
 
         if (edges != XDG_TOPLEVEL_RESIZE_EDGE_NONE)
             xdg_toplevel_resize(window->wl.xdg.toplevel, _glfw.wl.seat, serial, edges);
+        else if (_glfw.wl.pointerSurface == window->wl.fallback.top.surface)
+            xdg_toplevel_move(window->wl.xdg.toplevel, _glfw.wl.seat, serial);
     }
     else if (button == GLFW_MOUSE_BUTTON_RIGHT)
     {
@@ -1230,67 +1338,21 @@ static GLFWbool createNativeSurface(_GLFWwindow* window,
     return GLFW_TRUE;
 }
 
-static void setCursorImage(_GLFWwindow* window,
-                           _GLFWcursorWayland* cursorWayland)
-{
-    struct itimerspec timer = {0};
-    struct wl_cursor* wlCursor = cursorWayland->cursor;
-    struct wl_cursor_image* image;
-    struct wl_buffer* buffer;
-    struct wl_surface* surface = _glfw.wl.cursorSurface;
-    int scale = 1;
-
-    if (!wlCursor)
-        buffer = cursorWayland->buffer;
-    else
-    {
-        if (window->wl.bufferScale > 1 && cursorWayland->cursorHiDPI)
-        {
-            wlCursor = cursorWayland->cursorHiDPI;
-            scale = 2;
-        }
-
-        image = wlCursor->images[cursorWayland->currentImage];
-        buffer = wl_cursor_image_get_buffer(image);
-        if (!buffer)
-            return;
-
-        timer.it_value.tv_sec = image->delay / 1000;
-        timer.it_value.tv_nsec = (image->delay % 1000) * 1000000;
-        timerfd_settime(_glfw.wl.cursorTimerfd, 0, &timer, NULL);
-
-        cursorWayland->width = image->width;
-        cursorWayland->height = image->height;
-        cursorWayland->xhot = image->hotspot_x;
-        cursorWayland->yhot = image->hotspot_y;
-    }
-
-    wl_pointer_set_cursor(_glfw.wl.pointer, _glfw.wl.pointerEnterSerial,
-                          surface,
-                          cursorWayland->xhot / scale,
-                          cursorWayland->yhot / scale);
-    wl_surface_set_buffer_scale(surface, scale);
-    wl_surface_attach(surface, buffer, 0, 0);
-    wl_surface_damage(surface, 0, 0,
-                      cursorWayland->width, cursorWayland->height);
-    wl_surface_commit(surface);
-}
-
 static void incrementCursorImage(void)
 {
-    if (!_glfw.wl.pointerSurface)
-        return;
-
-    _GLFWwindow* window = wl_surface_get_user_data(_glfw.wl.pointerSurface);
-    if (window->wl.surface != _glfw.wl.pointerSurface)
-        return;
-
-    _GLFWcursor* cursor = window->cursor;
-    if (cursor && cursor->wl.cursor)
+    if (_glfw.wl.pointerSurface)
     {
-        cursor->wl.currentImage += 1;
-        cursor->wl.currentImage %= cursor->wl.cursor->image_count;
-        setCursorImage(window, &cursor->wl);
+        _GLFWwindow* window = wl_surface_get_user_data(_glfw.wl.pointerSurface);
+        if (window->wl.surface == _glfw.wl.pointerSurface)
+        {
+            _GLFWcursor* cursor = window->cursor;
+            if (cursor && cursor->wl.cursor)
+            {
+                cursor->wl.currentImage += 1;
+                cursor->wl.currentImage %= cursor->wl.cursor->image_count;
+                applyCursor(window);
+            }
+        }
     }
 }
 
@@ -1546,50 +1608,6 @@ static void processPointerLeaveSurface(struct wl_surface* surface)
         window->wl.resizeEdge = XDG_TOPLEVEL_RESIZE_EDGE_NONE;
         _glfwInputCursorEnter(window, GLFW_FALSE);
     }
-    else
-    {
-        if (window->wl.fallback.decorations)
-            window->wl.fallback.cursorName = NULL;
-    }
-}
-
-static uint32_t detectResizeEdge(_GLFWwindow* window, int x, int y)
-{
-    const int w = window->wl.width;
-    const int h = window->wl.height;
-    const int border = 8;
-
-    const GLFWbool onLeft   = (x < border);
-    const GLFWbool onRight  = (x >= w - border);
-    const GLFWbool onTop    = (y < border);
-    const GLFWbool onBottom = (y >= h - border);
-
-    if      (onTop    && onLeft)  return XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT;
-    else if (onTop    && onRight) return XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT;
-    else if (onBottom && onLeft)  return XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT;
-    else if (onBottom && onRight) return XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT;
-    else if (onTop)               return XDG_TOPLEVEL_RESIZE_EDGE_TOP;
-    else if (onBottom)            return XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM;
-    else if (onLeft)              return XDG_TOPLEVEL_RESIZE_EDGE_LEFT;
-    else if (onRight)             return XDG_TOPLEVEL_RESIZE_EDGE_RIGHT;
-
-    return XDG_TOPLEVEL_RESIZE_EDGE_NONE;
-}
-
-static const char* resizeEdgeCursorName(uint32_t edge)
-{
-    switch (edge)
-    {
-        case XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT:     return "nw-resize";
-        case XDG_TOPLEVEL_RESIZE_EDGE_TOP_RIGHT:    return "ne-resize";
-        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_LEFT:  return "sw-resize";
-        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM_RIGHT: return "se-resize";
-        case XDG_TOPLEVEL_RESIZE_EDGE_TOP:          return "n-resize";
-        case XDG_TOPLEVEL_RESIZE_EDGE_BOTTOM:       return "s-resize";
-        case XDG_TOPLEVEL_RESIZE_EDGE_LEFT:         return "w-resize";
-        case XDG_TOPLEVEL_RESIZE_EDGE_RIGHT:        return "e-resize";
-        default:                                    return NULL;
-    }
 }
 
 static void updateResizeEdge(_GLFWwindow* window)
@@ -1603,11 +1621,11 @@ static void updateResizeEdge(_GLFWwindow* window)
                                 (int) window->wl.cursorPosY);
     }
 
-    if (edge == window->wl.resizeEdge)
-        return;
-
-    window->wl.resizeEdge = edge;
-    _glfwSetCursorWayland(window, window->cursor);
+    if (edge != window->wl.resizeEdge)
+    {
+        window->wl.resizeEdge = edge;
+        applyCursor(window);
+    }
 }
 
 static void processPointerMotion(double xpos, double ypos)
@@ -1626,7 +1644,11 @@ static void processPointerMotion(double xpos, double ypos)
     else
     {
         if (window->wl.fallback.decorations)
-            updateFallbackDecorationCursor(window, xpos, ypos);
+        {
+            window->wl.fallback.pointerX = xpos;
+            window->wl.fallback.pointerY = ypos;
+            applyCursor(window);
+        }
     }
 }
 
@@ -3421,52 +3443,7 @@ void _glfwSetCursorWayland(_GLFWwindow* window, _GLFWcursor* cursor)
             unconfinePointer(window);
     }
 
-    if (window->cursorMode == GLFW_CURSOR_NORMAL ||
-        window->cursorMode == GLFW_CURSOR_CAPTURED)
-    {
-        // Resize edge cursor takes priority over the application cursor
-        if (window->wl.resizeEdge != XDG_TOPLEVEL_RESIZE_EDGE_NONE)
-        {
-            setNamedCursor(window, resizeEdgeCursorName(window->wl.resizeEdge));
-        }
-        else if (cursor)
-            setCursorImage(window, &cursor->wl);
-        else
-        {
-            struct wl_cursor* defaultCursor =
-                wl_cursor_theme_get_cursor(_glfw.wl.cursorTheme, "left_ptr");
-            if (!defaultCursor)
-            {
-                _glfwInputError(GLFW_PLATFORM_ERROR,
-                                "Wayland: Standard cursor not found");
-                return;
-            }
-
-            struct wl_cursor* defaultCursorHiDPI = NULL;
-            if (_glfw.wl.cursorThemeHiDPI)
-            {
-                defaultCursorHiDPI =
-                    wl_cursor_theme_get_cursor(_glfw.wl.cursorThemeHiDPI, "left_ptr");
-            }
-
-            _GLFWcursorWayland cursorWayland =
-            {
-                defaultCursor,
-                defaultCursorHiDPI,
-                NULL,
-                0, 0,
-                0, 0,
-                0
-            };
-
-            setCursorImage(window, &cursorWayland);
-        }
-    }
-    else if (window->cursorMode == GLFW_CURSOR_HIDDEN ||
-             window->cursorMode == GLFW_CURSOR_DISABLED)
-    {
-        wl_pointer_set_cursor(_glfw.wl.pointer, _glfw.wl.pointerEnterSerial, NULL, 0, 0);
-    }
+    applyCursor(window);
 }
 
 static void dataSourceHandleTarget(void* userData,

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -54,6 +54,7 @@
 #include "idle-inhibit-unstable-v1-client-protocol.h"
 #include "xdg-toplevel-drag-v1-client-protocol.h"
 #include "fractional-scale-v1-client-protocol.h"
+#include "kde-shadow-client-protocol.h"
 
 // Marker mime for self-initiated toplevel drags; no payload transferred.
 #define GLFW_WAYLAND_WINDOW_DRAG_MIME "application/x.glfw-window-drag"
@@ -263,6 +264,120 @@ static struct wl_buffer* createShmBuffer(const GLFWimage* image)
     wl_shm_pool_destroy(pool);
 
     return buffer;
+}
+
+static struct wl_buffer* createShadowTile(int width, int height,
+                                          float maxAlpha,
+                                          GLFWbool horizontal, GLFWbool vertical,
+                                          GLFWbool invertX, GLFWbool invertY)
+{
+    const int stride = width * 4;
+    const int length = stride * height;
+    const int fd = createAnonymousFile(length);
+    if (fd < 0)
+        return NULL;
+
+    unsigned char* data = mmap(NULL, length, PROT_READ | PROT_WRITE,
+                               MAP_SHARED, fd, 0);
+    if (data == MAP_FAILED)
+    {
+        close(fd);
+        return NULL;
+    }
+
+    struct wl_shm_pool* pool = wl_shm_create_pool(_glfw.wl.shm, fd, length);
+    close(fd);
+
+    for (int y = 0; y < height; y++)
+    {
+        for (int x = 0; x < width; x++)
+        {
+            // dx/dy = 0 at window edge, 1 at outer edge
+            float dx = horizontal ? (float)x / (width > 1 ? width - 1 : 1) : 0.0f;
+            float dy = vertical   ? (float)y / (height > 1 ? height - 1 : 1) : 0.0f;
+            if (invertX) dx = 1.0f - dx;
+            if (invertY) dy = 1.0f - dy;
+            float d2 = dx * dx + dy * dy + dx * dy;
+            const float k = 8.0f;
+            const float tail = expf(-k);
+            float alpha = maxAlpha * fmaxf(0.0f, expf(-k * d2) - tail) / (1.0f - tail);
+            unsigned char a = (unsigned char)(alpha * 255.0f + 0.5f);
+            int off = (y * width + x) * 4;
+            data[off + 0] = 0;
+            data[off + 1] = 0;
+            data[off + 2] = 0;
+            data[off + 3] = a;
+        }
+    }
+
+    struct wl_buffer* buffer =
+        wl_shm_pool_create_buffer(pool, 0, width, height,
+                                  stride, WL_SHM_FORMAT_ARGB8888);
+    munmap(data, length);
+    wl_shm_pool_destroy(pool);
+    return buffer;
+}
+
+// KDE shadow tiles: top-left, top, top-right, right,
+//                   bottom-right, bottom, bottom-left, left
+static void createKdeShadow(_GLFWwindow* window, GLFWbool focused)
+{
+    if (!_glfw.wl.shadowManager)
+        return;
+
+    const int sz = 64;
+    const float maxAlpha = focused ? 0.17f : 0.10f;
+
+    // d=0 is opaque (window edge), d=1 is transparent (outer edge).
+    // invertX/invertY put d=0 on the side facing the window.
+    window->wl.shadowBuffers[0] = createShadowTile(sz, sz, maxAlpha, GLFW_TRUE, GLFW_TRUE, GLFW_TRUE, GLFW_TRUE);     // top-left
+    window->wl.shadowBuffers[1] = createShadowTile(1, sz, maxAlpha, GLFW_FALSE, GLFW_TRUE, GLFW_FALSE, GLFW_TRUE);    // top
+    window->wl.shadowBuffers[2] = createShadowTile(sz, sz, maxAlpha, GLFW_TRUE, GLFW_TRUE, GLFW_FALSE, GLFW_TRUE);    // top-right
+    window->wl.shadowBuffers[3] = createShadowTile(sz, 1, maxAlpha, GLFW_TRUE, GLFW_FALSE, GLFW_FALSE, GLFW_FALSE);   // right
+    window->wl.shadowBuffers[4] = createShadowTile(sz, sz, maxAlpha, GLFW_TRUE, GLFW_TRUE, GLFW_FALSE, GLFW_FALSE);   // bottom-right
+    window->wl.shadowBuffers[5] = createShadowTile(1, sz, maxAlpha, GLFW_FALSE, GLFW_TRUE, GLFW_FALSE, GLFW_FALSE);   // bottom
+    window->wl.shadowBuffers[6] = createShadowTile(sz, sz, maxAlpha, GLFW_TRUE, GLFW_TRUE, GLFW_TRUE, GLFW_FALSE);    // bottom-left
+    window->wl.shadowBuffers[7] = createShadowTile(sz, 1, maxAlpha, GLFW_TRUE, GLFW_FALSE, GLFW_TRUE, GLFW_FALSE);    // left
+
+    window->wl.shadow = org_kde_kwin_shadow_manager_create(
+        _glfw.wl.shadowManager, window->wl.surface);
+
+    org_kde_kwin_shadow_attach_top_left(window->wl.shadow, window->wl.shadowBuffers[0]);
+    org_kde_kwin_shadow_attach_top(window->wl.shadow, window->wl.shadowBuffers[1]);
+    org_kde_kwin_shadow_attach_top_right(window->wl.shadow, window->wl.shadowBuffers[2]);
+    org_kde_kwin_shadow_attach_right(window->wl.shadow, window->wl.shadowBuffers[3]);
+    org_kde_kwin_shadow_attach_bottom_right(window->wl.shadow, window->wl.shadowBuffers[4]);
+    org_kde_kwin_shadow_attach_bottom(window->wl.shadow, window->wl.shadowBuffers[5]);
+    org_kde_kwin_shadow_attach_bottom_left(window->wl.shadow, window->wl.shadowBuffers[6]);
+    org_kde_kwin_shadow_attach_left(window->wl.shadow, window->wl.shadowBuffers[7]);
+
+    wl_fixed_t offset = wl_fixed_from_int(sz);
+    org_kde_kwin_shadow_set_top_offset(window->wl.shadow, offset);
+    org_kde_kwin_shadow_set_right_offset(window->wl.shadow, offset);
+    org_kde_kwin_shadow_set_bottom_offset(window->wl.shadow, offset);
+    org_kde_kwin_shadow_set_left_offset(window->wl.shadow, offset);
+
+    org_kde_kwin_shadow_commit(window->wl.shadow);
+}
+
+static void destroyKdeShadow(_GLFWwindow* window)
+{
+    if (window->wl.shadow)
+    {
+        if (wl_proxy_get_version((struct wl_proxy*) window->wl.shadow) >= ORG_KDE_KWIN_SHADOW_DESTROY_SINCE_VERSION)
+            org_kde_kwin_shadow_destroy(window->wl.shadow);
+        else
+            wl_proxy_destroy((struct wl_proxy*) window->wl.shadow);
+        window->wl.shadow = NULL;
+    }
+    for (int i = 0; i < 8; i++)
+    {
+        if (window->wl.shadowBuffers[i])
+        {
+            wl_buffer_destroy(window->wl.shadowBuffers[i]);
+            window->wl.shadowBuffers[i] = NULL;
+        }
+    }
 }
 
 static void createFallbackEdge(_GLFWwindow* window,
@@ -662,7 +777,7 @@ static void resizeFramebuffer(_GLFWwindow* window)
                              0, 0);
     }
 
-    if (!window->wl.transparent)
+    if (!window->wl.transparent && window->decorated)
         setContentAreaOpaque(window);
 
     _glfwInputFramebufferSize(window, window->wl.fbWidth, window->wl.fbHeight);
@@ -1608,11 +1723,15 @@ static GLFWbool createShellObjects(_GLFWwindow* window)
     if (ok)
         armMappedFrameCallback(window);
 
+    if (ok && !window->decorated)
+        createKdeShadow(window, GLFW_TRUE);
+
     return ok;
 }
 
 static void destroyShellObjects(_GLFWwindow* window)
 {
+    destroyKdeShadow(window);
     destroyFallbackDecorations(window);
 
     if (window->wl.libdecor.frame)
@@ -1675,7 +1794,7 @@ static GLFWbool createNativeSurface(_GLFWwindow* window,
     window->wl.maximized = wndconfig->maximized;
 
     window->wl.transparent = fbconfig->transparent;
-    if (!window->wl.transparent)
+    if (!window->wl.transparent && window->decorated)
         setContentAreaOpaque(window);
 
     if (_glfw.wl.fractionalScaleManager)
@@ -2452,6 +2571,11 @@ static void keyboardHandleEnter(void* userData,
 
     _glfw.wl.serial = serial;
     _glfw.wl.keyboardFocus = window;
+    if (!window->decorated && window->wl.shadow)
+    {
+        destroyKdeShadow(window);
+        createKdeShadow(window, GLFW_TRUE);
+    }
     _glfwInputWindowFocus(window, GLFW_TRUE);
 }
 
@@ -2470,6 +2594,12 @@ static void keyboardHandleLeave(void* userData,
 
     _glfw.wl.serial = serial;
     _glfw.wl.keyboardFocus = NULL;
+
+    if (!window->decorated && window->wl.shadow)
+    {
+        destroyKdeShadow(window);
+        createKdeShadow(window, GLFW_FALSE);
+    }
 
     // _glfwInputWindowFocus synthesizes button releases, but during a drag
     // the physical button is still held. Hide button state across the call.

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -3257,7 +3257,7 @@ GLFWbool _glfwCreateStandardCursorWayland(_GLFWcursor* cursor, int shape)
     }
 
     _GLFWcursorWayland cw = lookupNamedCursor(desc->name, desc->fallback);
-    if (!cw.cursor)
+    if (!cw.cursor && !_glfw.wl.cursorShapeManager)
     {
         _glfwInputError(GLFW_CURSOR_UNAVAILABLE,
                         "Wayland: Failed to create standard cursor \"%s\"",

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -941,6 +941,14 @@ static void xdgToplevelHandleConfigure(void* userData,
             window->wl.pending.height = height;
         }
     }
+    else if ((window->wl.maximized && !window->wl.pending.maximized) ||
+             (window->wl.fullscreen && !window->wl.pending.fullscreen))
+    {
+        // Transitioning out of maximized/fullscreen with no suggested size:
+        // restore the saved floating size.
+        window->wl.pending.width  = window->wl.floatingWidth;
+        window->wl.pending.height = window->wl.floatingHeight;
+    }
     else
     {
         window->wl.pending.width  = window->wl.width;
@@ -1001,6 +1009,9 @@ static void xdgSurfaceHandleConfigure(void* userData,
             else if (aspectRatio > targetRatio)
                 width = height * targetRatio;
         }
+
+        window->wl.floatingWidth = width;
+        window->wl.floatingHeight = height;
     }
 
     if (resizeWindow(window, width, height))
@@ -1053,8 +1064,19 @@ void libdecorFrameHandleConfigure(struct libdecor_frame* frame,
 
     if (!libdecor_configuration_get_content_size(config, frame, &width, &height))
     {
-        width = window->wl.width;
-        height = window->wl.height;
+        // Transitioning out of maximized/fullscreen: restore the saved
+        // floating size so the window doesn't stay screen-sized.
+        if ((window->wl.maximized && !maximized) ||
+            (window->wl.fullscreen && !fullscreen))
+        {
+            width = window->wl.floatingWidth;
+            height = window->wl.floatingHeight;
+        }
+        else
+        {
+            width = window->wl.width;
+            height = window->wl.height;
+        }
     }
 
     if (!maximized && !fullscreen)
@@ -1068,6 +1090,9 @@ void libdecorFrameHandleConfigure(struct libdecor_frame* frame,
             else if (aspectRatio > targetRatio)
                 width = height * targetRatio;
         }
+
+        window->wl.floatingWidth = width;
+        window->wl.floatingHeight = height;
     }
 
     struct libdecor_state* frameState = libdecor_state_new(width, height);
@@ -1637,6 +1662,8 @@ static GLFWbool createNativeSurface(_GLFWwindow* window,
 
     window->wl.width = wndconfig->width;
     window->wl.height = wndconfig->height;
+    window->wl.floatingWidth = wndconfig->width;
+    window->wl.floatingHeight = wndconfig->height;
     window->wl.fbWidth = wndconfig->width;
     window->wl.fbHeight = wndconfig->height;
     window->wl.appId = _glfw_strdup(wndconfig->wl.appId);
@@ -3187,6 +3214,12 @@ void _glfwSetWindowSizeWayland(_GLFWwindow* window, int width, int height)
     {
         if (!resizeWindow(window, width, height))
             return;
+
+        if (!window->wl.maximized && !window->wl.fullscreen)
+        {
+            window->wl.floatingWidth = width;
+            window->wl.floatingHeight = height;
+        }
 
         if (window->wl.libdecor.frame)
         {

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -62,27 +62,19 @@
 #define GLFW_PENDING_SCROLL     8
 #define GLFW_PENDING_DISCRETE   16
 
-// Unified cursor descriptor table.  Each row maps a GLFW standard cursor
-// shape and/or an xdg_toplevel resize edge to the wp_cursor_shape protocol
-// enum, plus XDG and X11 fallback cursor name strings for compositors that
-// don't support wp_cursor_shape_v1.
-//
-// Rows with resizeEdge == NONE are the canonical entries for a GLFW shape
-// (used by _glfwCreateStandardCursorWayland).  Rows with a specific edge
-// are used by applyCursor for directional resize cursors.
-//
 typedef struct {
     int                 glfwShape;  // GLFW_*_CURSOR
-    uint32_t            resizeEdge; // XDG_TOPLEVEL_RESIZE_EDGE_* (NONE if N/A)
+    uint32_t            resizeEdge; // XDG_TOPLEVEL_RESIZE_EDGE_* (NONE for non-resizing-related shapes)
     uint32_t            shape;      // WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_*
     const char*         name;       // XDG cursor name
     const char*         fallback;   // X11 core cursor name
 } _GLFWcursorDesc;
 
+// This table relates various mouse-cursor-shape-related constants to each other so if you already
+// have one you can find an equivalent value for a different library/context.
 static const _GLFWcursorDesc cursorTable[] =
 {
-    // Non-resize cursors
-    { GLFW_ARROW_CURSOR,         XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_DEFAULT,     "default",       "left_ptr"            },
+    { GLFW_ARROW_CURSOR,         XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_DEFAULT,     "default",       "left_ptr"           },
     { GLFW_IBEAM_CURSOR,         XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_TEXT,        "text",          "xterm"              },
     { GLFW_CROSSHAIR_CURSOR,     XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_CROSSHAIR,   "crosshair",     "crosshair"          },
     { GLFW_POINTING_HAND_CURSOR, XDG_TOPLEVEL_RESIZE_EDGE_NONE,        WP_CURSOR_SHAPE_DEVICE_V1_SHAPE_POINTER,     "pointer",       "hand2"              },
@@ -1733,8 +1725,7 @@ static void processPointerButton(int button, int action)
         GLFWbool handled = GLFW_FALSE;
 
         if (button == GLFW_MOUSE_BUTTON_LEFT && action == GLFW_PRESS &&
-            !window->decorated && !window->monitor &&
-            !window->wl.maximized && !window->wl.fullscreen)
+            !window->decorated && !window->monitor)
         {
             struct xdg_toplevel* toplevel = window->wl.xdg.toplevel;
             if (window->wl.libdecor.frame)
@@ -1744,9 +1735,14 @@ static void processPointerButton(int button, int action)
             {
                 const int x = (int) window->wl.cursorPosX;
                 const int y = (int) window->wl.cursorPosY;
-                uint32_t edges = window->resizable
-                    ? detectResizeEdge(window, x, y)
-                    : XDG_TOPLEVEL_RESIZE_EDGE_NONE;
+
+                // Resize edges are only active when not maximized/fullscreen
+                uint32_t edges = XDG_TOPLEVEL_RESIZE_EDGE_NONE;
+                if (window->resizable &&
+                    !window->wl.maximized && !window->wl.fullscreen)
+                {
+                    edges = detectResizeEdge(window, x, y);
+                }
 
                 if (edges != XDG_TOPLEVEL_RESIZE_EDGE_NONE)
                 {

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -1973,7 +1973,12 @@ static void processPointerLeaveSurface(struct wl_surface* surface)
     if (window->wl.surface == surface)
     {
         window->wl.resizeEdge = XDG_TOPLEVEL_RESIZE_EDGE_NONE;
-        _glfwInputCursorEnter(window, GLFW_FALSE);
+        // During a toplevel drag session, the compositor steals the pointer
+        // for DnD. Suppress the cursor-leave notification so the application
+        // doesn't park the cursor at FLT_MAX and lose hover state. DnD
+        // enter/motion events provide cursor position while the drag is live.
+        if (!_glfw.wl.toplevelDragSession.source)
+            _glfwInputCursorEnter(window, GLFW_FALSE);
     }
 }
 
@@ -2022,6 +2027,16 @@ static void processPointerMotion(double xpos, double ypos)
 
 static void processPointerButton(int button, int action)
 {
+    // When a toplevel drag session is active, the compositor sends a button
+    // release as it transfers the implicit grab to the DnD session. Suppress
+    // it so the application's input state keeps the button held throughout
+    // the drag. endToplevelDragSession synthesizes the release when done.
+    if (_glfw.wl.toplevelDragSession.source &&
+        button == GLFW_MOUSE_BUTTON_LEFT && action == GLFW_RELEASE)
+    {
+        return;
+    }
+
     _GLFWwindow* window = wl_surface_get_user_data(_glfw.wl.pointerSurface);
     if (window->wl.surface == _glfw.wl.pointerSurface)
     {
@@ -2175,6 +2190,18 @@ static void pointerHandleButton(void* userData,
         return;
 
     _glfw.wl.serial = serial;
+
+    // Suppress the button release the compositor sends when transferring the
+    // implicit grab to the DnD session. Without this, pointerButtonsDown drops
+    // to 0 and downstream logic thinks no button is held during the drag.
+    const int btnIdx = buttonID - BTN_LEFT;
+    if (_glfw.wl.toplevelDragSession.source &&
+        btnIdx == GLFW_MOUSE_BUTTON_LEFT &&
+        state != WL_POINTER_BUTTON_STATE_PRESSED)
+    {
+        return;
+    }
+
     if (state == WL_POINTER_BUTTON_STATE_PRESSED)
     {
         _glfw.wl.pointerButtonSerial = serial;
@@ -2450,7 +2477,29 @@ static void keyboardHandleLeave(void* userData,
 
     _glfw.wl.serial = serial;
     _glfw.wl.keyboardFocus = NULL;
-    _glfwInputWindowFocus(window, GLFW_FALSE);
+
+    // On Wayland, keyboard focus follows the pointer. Creating a new window
+    // under the cursor triggers wl_keyboard.leave on the old window, and
+    // _glfwInputWindowFocus synthesizes button releases for all held buttons.
+    // This is wrong when the physical button is still held (e.g. mid-drag
+    // tab tear-out). Temporarily mark buttons as released so
+    // _glfwInputWindowFocus's loop has nothing to release, then restore them.
+    if (_glfw.wl.pointerButtonsDown > 0)
+    {
+        GLFWbool savedButtons[GLFW_MOUSE_BUTTON_LAST + 1];
+        for (int i = 0; i <= GLFW_MOUSE_BUTTON_LAST; i++)
+        {
+            savedButtons[i] = window->mouseButtons[i];
+            window->mouseButtons[i] = GLFW_RELEASE;
+        }
+        _glfwInputWindowFocus(window, GLFW_FALSE);
+        for (int i = 0; i <= GLFW_MOUSE_BUTTON_LAST; i++)
+            window->mouseButtons[i] = savedButtons[i];
+    }
+    else
+    {
+        _glfwInputWindowFocus(window, GLFW_FALSE);
+    }
 }
 
 static void keyboardHandleKey(void* userData,
@@ -2726,7 +2775,9 @@ static void dataDeviceHandleEnter(void* userData,
     }
 
     if (i == _glfw.wl.offerCount)
+    {
         return;
+    }
 
     if (surface && wl_proxy_get_tag((struct wl_proxy*) surface) == &_glfw.wl.tag)
     {
@@ -2741,16 +2792,8 @@ static void dataDeviceHandleEnter(void* userData,
 
                 wl_data_offer_accept(offer, serial, "text/uri-list");
             }
-            else if (_glfw.wl.offers[i].glfw_window_drag &&
-                     window != _glfw.wl.toplevelDragSession.window)
+            else if (_glfw.wl.offers[i].glfw_window_drag)
             {
-                // Our own xdg_toplevel_drag session. Ignore enters on the
-                // *dragged* window itself — per the xdg-shell spec the
-                // attached toplevel doesn't participate in drop-target
-                // selection, but KWin has been observed to deliver DnD
-                // events to it anyway. Forwarding those as cursor motion
-                // would trigger hover effects on the dragged window's own
-                // widgets while the user is dragging.
                 _glfw.wl.dragOffer = offer;
                 _glfw.wl.dragFocus = window;
                 _glfw.wl.dragSerial = serial;
@@ -2766,20 +2809,6 @@ static void dataDeviceHandleEnter(void* userData,
                 const double xpos = wl_fixed_to_double(x);
                 const double ypos = wl_fixed_to_double(y);
                 _glfwInputCursorPos(window, xpos, ypos);
-
-                // Re-sync dragged window position (see dataDeviceHandleMotion)
-                _GLFWwindow* dragged = _glfw.wl.toplevelDragSession.window;
-                if (dragged)
-                {
-                    int newX = window->wl.pendingPosX
-                             + (int) lround(xpos) - _glfw.wl.toplevelDragSession.offsetX;
-                    int newY = window->wl.pendingPosY
-                             + (int) lround(ypos) - _glfw.wl.toplevelDragSession.offsetY;
-                    dragged->wl.pendingPosX = newX;
-                    dragged->wl.pendingPosY = newY;
-                    dragged->wl.pendingPosSet = GLFW_TRUE;
-                    _glfwInputWindowPos(dragged, newX, newY);
-                }
             }
         }
     }
@@ -2837,13 +2866,8 @@ static void dataDeviceHandleMotion(void* userData,
         const double ypos = wl_fixed_to_double(y);
         _glfwInputCursorPos(_glfw.wl.dragFocus, xpos, ypos);
 
-        // Re-synchronize the dragged window's stored position from the
-        // compositor's actual placement.  The cursor is at (xpos, ypos) in
-        // dragFocus's surface frame and the dragged toplevel was attached
-        // at (offsetX, offsetY) from the cursor, so the dragged window's
-        // origin is at (cursor - offset) relative to dragFocus's origin.
         _GLFWwindow* dragged = _glfw.wl.toplevelDragSession.window;
-        if (dragged && _glfw.wl.dragFocus != dragged)
+        if (dragged)
         {
             int newX = _glfw.wl.dragFocus->wl.pendingPosX
                      + (int) lround(xpos) - _glfw.wl.toplevelDragSession.offsetX;
@@ -3592,22 +3616,17 @@ static GLFWbool startToplevelDragSession(_GLFWwindow* window, uint32_t serial)
     // passing (0, 0) snaps the window so the cursor is in its top-left
     // corner.
     //
+    // Compute where the cursor sits relative to the toplevel's top-left.
+    //
     // Two cases:
-    //  - Dragging the window that received the press (regular titlebar
-    //    drag): use that window's own tracked cursor position.
-    //  - Press-on-other-window: the press happened on a different window
-    //    than the one being dragged (the caller may have created a new
-    //    toplevel for the drag under the cursor). The new toplevel hasn't
-    //    received any motion events yet, so its cursorPosX/Y is 0, which
-    //    is why it grabs from the top-left. Compute the cursor position
-    //    inside the new window as the source window's cursor pos minus
-    //    the new window's caller-intended position (passed via an earlier
-    //    glfwSetWindowPos before show).
-    // Use the cursor position captured at the press itself, not the live
-    // cursor pos — it drifts between the press and when SetWindowPos
-    // actually triggers this drag, and the drift varied per-drag.
-    // Round rather than truncate so fractional cursor positions don't
-    // systematically lose a pixel to the bottom-left.
+    //  - Same-window drag (regular titlebar drag): use the window's own
+    //    tracked cursor position — it's current and surface-local.
+    //  - Cross-window drag (tab tear-out): the press happened on a
+    //    different surface (main window's tab bar), a new toplevel was
+    //    created under the cursor, and its pendingPos was set from the
+    //    CURRENT cursor minus ImGui's click offset. Use the origin
+    //    window's live cursor (not the press-time capture) so the
+    //    compositor attachment offset matches ImGui's click offset.
     double rawOffsetX, rawOffsetY;
     if (_glfw.wl.pointerButtonSurface == window->wl.surface)
     {
@@ -3616,11 +3635,10 @@ static GLFWbool startToplevelDragSession(_GLFWwindow* window, uint32_t serial)
     }
     else
     {
-        // Tab-tear: press was on a different surface (main window's tab
-        // bar). Convert the press position into the new window's surface
-        // coords by subtracting the new window's intended top-left.
-        rawOffsetX = _glfw.wl.pointerButtonX - window->wl.pendingPosX;
-        rawOffsetY = _glfw.wl.pointerButtonY - window->wl.pendingPosY;
+        _GLFWwindow* origin = wl_surface_get_user_data(
+            _glfw.wl.pointerButtonSurface);
+        rawOffsetX = origin->wl.cursorPosX - window->wl.pendingPosX;
+        rawOffsetY = origin->wl.cursorPosY - window->wl.pendingPosY;
     }
     int offsetX = (int) lround(rawOffsetX);
     int offsetY = (int) lround(rawOffsetY);

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -50,7 +50,14 @@
 #include "pointer-constraints-unstable-v1-client-protocol.h"
 #include "xdg-activation-v1-client-protocol.h"
 #include "idle-inhibit-unstable-v1-client-protocol.h"
+#include "xdg-toplevel-drag-v1-client-protocol.h"
 #include "fractional-scale-v1-client-protocol.h"
+
+// Mime type advertised by the wl_data_source we create for self-initiated
+// toplevel drags (see _glfwDragWindowWayland). No actual payload is
+// transferred — it's just a marker so the compositor will deliver
+// wl_data_device enter/motion/leave events to this client's surfaces.
+#define GLFW_WAYLAND_WINDOW_DRAG_MIME "application/x.glfw-window-drag"
 #include "cursor-shape-v1-client-protocol.h"
 
 #define GLFW_BORDER_SIZE    4
@@ -1476,6 +1483,8 @@ static GLFWbool createXdgShellObjects(_GLFWwindow* window)
     return GLFW_TRUE;
 }
 
+static GLFWbool startToplevelDragSession(_GLFWwindow* window, uint32_t serial);
+
 static void issuePendingDragMove(_GLFWwindow* window)
 {
     if (!window->wl.dragPending || !_glfw.wl.seat)
@@ -1487,6 +1496,9 @@ static void issuePendingDragMove(_GLFWwindow* window)
     if (_glfw.wl.pointerButtonsDown <= 0)
         return;
 
+    if (startToplevelDragSession(window, window->wl.dragPendingSerial))
+        return;
+
     struct xdg_toplevel* toplevel = window->wl.xdg.toplevel;
     if (!toplevel && window->wl.libdecor.frame)
         toplevel = libdecor_frame_get_xdg_toplevel(window->wl.libdecor.frame);
@@ -1494,6 +1506,11 @@ static void issuePendingDragMove(_GLFWwindow* window)
         return;
 
     xdg_toplevel_move(toplevel, _glfw.wl.seat, window->wl.dragPendingSerial);
+
+    // Fallback path: compositor swallows release, synthesize one.
+    if (_glfw.wl.pointerButtonsDown > 0)
+        _glfw.wl.pointerButtonsDown--;
+    _glfwInputMouseClick(window, GLFW_MOUSE_BUTTON_LEFT, GLFW_RELEASE, 0);
 }
 
 static void mappedFrameHandleDone(void* userData,
@@ -2119,6 +2136,7 @@ static void pointerHandleButton(void* userData,
     if (state == WL_POINTER_BUTTON_STATE_PRESSED)
     {
         _glfw.wl.pointerButtonSerial = serial;
+        _glfw.wl.pointerButtonSurface = _glfw.wl.pointerSurface;
         _glfw.wl.pointerButtonsDown++;
     }
     else if (_glfw.wl.pointerButtonsDown > 0)
@@ -2579,15 +2597,36 @@ static void dataOfferHandleOffer(void* userData,
                 _glfw.wl.offers[i].text_plain_utf8 = GLFW_TRUE;
             else if (strcmp(mimeType, "text/uri-list") == 0)
                 _glfw.wl.offers[i].text_uri_list = GLFW_TRUE;
+            else if (strcmp(mimeType, GLFW_WAYLAND_WINDOW_DRAG_MIME) == 0)
+                _glfw.wl.offers[i].glfw_window_drag = GLFW_TRUE;
 
             break;
         }
     }
 }
 
+static void dataOfferHandleSourceActions(void* userData,
+                                         struct wl_data_offer* offer,
+                                         uint32_t source_actions)
+{
+    // v3+ only. We don't act on it directly — the source's advertised action
+    // set is negotiated by the compositor and reported back via .action.
+    (void)userData; (void)offer; (void)source_actions;
+}
+
+static void dataOfferHandleAction(void* userData,
+                                  struct wl_data_offer* offer,
+                                  uint32_t dnd_action)
+{
+    // v3+ only. No-op: we don't branch behavior on the negotiated action.
+    (void)userData; (void)offer; (void)dnd_action;
+}
+
 static const struct wl_data_offer_listener dataOfferListener =
 {
-    dataOfferHandleOffer
+    dataOfferHandleOffer,
+    dataOfferHandleSourceActions,
+    dataOfferHandleAction,
 };
 
 static void dataDeviceHandleDataOffer(void* userData,
@@ -2649,6 +2688,28 @@ static void dataDeviceHandleEnter(void* userData,
 
                 wl_data_offer_accept(offer, serial, "text/uri-list");
             }
+            else if (_glfw.wl.offers[i].glfw_window_drag)
+            {
+                // Our own xdg_toplevel_drag session. Accept so the compositor
+                // keeps sending motion events to this surface, and prime the
+                // cursor position so the app sees the drag entering this
+                // window.
+                _glfw.wl.dragOffer = offer;
+                _glfw.wl.dragFocus = window;
+                _glfw.wl.dragSerial = serial;
+
+                wl_data_offer_accept(offer, serial, GLFW_WAYLAND_WINDOW_DRAG_MIME);
+                if (wl_data_offer_get_version(offer) >= 3)
+                {
+                    wl_data_offer_set_actions(offer,
+                        WL_DATA_DEVICE_MANAGER_DND_ACTION_MOVE,
+                        WL_DATA_DEVICE_MANAGER_DND_ACTION_MOVE);
+                }
+
+                const double xpos = wl_fixed_to_double(x);
+                const double ypos = wl_fixed_to_double(y);
+                _glfwInputCursorPos(window, xpos, ypos);
+            }
         }
     }
 
@@ -2679,6 +2740,16 @@ static void dataDeviceHandleMotion(void* userData,
                                    wl_fixed_t x,
                                    wl_fixed_t y)
 {
+    // During our own toplevel drag, the compositor captures pointer input,
+    // so wl_pointer.motion never fires. Forward the DnD motion as a cursor
+    // move so the client sees the drag passing over its surfaces and can
+    // drive drop-target hit-testing (dock regions, etc.) in ImGui.
+    if (_glfw.wl.dragFocus && _glfw.wl.toplevelDragSession.source)
+    {
+        const double xpos = wl_fixed_to_double(x);
+        const double ypos = wl_fixed_to_double(y);
+        _glfwInputCursorPos(_glfw.wl.dragFocus, xpos, ypos);
+    }
 }
 
 static void dataDeviceHandleDrop(void* userData,
@@ -2686,6 +2757,23 @@ static void dataDeviceHandleDrop(void* userData,
 {
     if (!_glfw.wl.dragOffer)
         return;
+
+    // For a self-initiated toplevel drag we have no payload to transfer; just
+    // finish the offer so the compositor completes the drag protocol and
+    // dnd_finished fires on the source. Without this the compositor keeps
+    // the drag in a half-completed state and normal pointer input stays
+    // routed to DnD handlers instead of returning to the application.
+    if (_glfw.wl.toplevelDragSession.source)
+    {
+        // wl_data_offer.finish and set_actions are v3+. Calling either on
+        // an older offer raises a protocol error (which aborts the client).
+        if (wl_data_offer_get_version(_glfw.wl.dragOffer) >= 3)
+            wl_data_offer_finish(_glfw.wl.dragOffer);
+        wl_data_offer_destroy(_glfw.wl.dragOffer);
+        _glfw.wl.dragOffer = NULL;
+        _glfw.wl.dragFocus = NULL;
+        return;
+    }
 
     char* string = readDataOfferAsString(_glfw.wl.dragOffer, "text/uri-list");
     if (string)
@@ -3247,17 +3335,207 @@ void _glfwFocusWindowWayland(_GLFWwindow* window)
     xdg_activation_token_v1_commit(window->wl.activationToken);
 }
 
+static void endToplevelDragSession(void)
+{
+    _GLFWwindow* window = _glfw.wl.toplevelDragSession.window;
+
+    if (_glfw.wl.toplevelDragSession.drag)
+    {
+        xdg_toplevel_drag_v1_destroy(_glfw.wl.toplevelDragSession.drag);
+        _glfw.wl.toplevelDragSession.drag = NULL;
+    }
+    if (_glfw.wl.toplevelDragSession.source)
+    {
+        wl_data_source_destroy(_glfw.wl.toplevelDragSession.source);
+        _glfw.wl.toplevelDragSession.source = NULL;
+    }
+    _glfw.wl.toplevelDragSession.window = NULL;
+
+    // Also decrement the counter since the real wl_pointer.button release was
+    // consumed by the compositor for the drag. Keeping it above zero would
+    // wrongly suggest a button is still held for future logic (deferred move
+    // gates, drag trigger heuristics, ...).
+    if (_glfw.wl.pointerButtonsDown > 0)
+        _glfw.wl.pointerButtonsDown--;
+
+    // Synthesize the swallowed left-button release so the application's
+    // input pipeline gets to see "drag ended" and run its drop logic
+    // (e.g. ImGui dock-to-target detection).
+    if (window)
+        _glfwInputMouseClick(window, GLFW_MOUSE_BUTTON_LEFT, GLFW_RELEASE, 0);
+}
+
+static void dragSourceHandleTarget(void* data,
+                                   struct wl_data_source* source,
+                                   const char* mime) { (void)data; (void)source; (void)mime; }
+
+static void dragSourceHandleSend(void* data, struct wl_data_source* source,
+                                 const char* mime, int32_t fd)
+{
+    // No payload is transferred — this data source exists only to carry the
+    // xdg_toplevel_drag attachment. Close the fd so the reader doesn't hang.
+    (void)data; (void)source; (void)mime;
+    close(fd);
+}
+
+static void dragSourceHandleCancelled(void* data, struct wl_data_source* source)
+{
+    (void)data; (void)source;
+    endToplevelDragSession();
+}
+
+static void dragSourceHandleDndDropPerformed(void* data, struct wl_data_source* source)
+{
+    (void)data; (void)source;
+    // The user released. Clean up here rather than waiting for
+    // dnd_finished: the latter only fires if a target actually called
+    // wl_data_offer_finish, which we can't guarantee when the drop lands
+    // on a foreign client. endToplevelDragSession is idempotent (clears
+    // its own state) so a later dnd_finished is a safe no-op.
+    endToplevelDragSession();
+}
+
+static void dragSourceHandleDndFinished(void* data, struct wl_data_source* source)
+{
+    (void)data; (void)source;
+    endToplevelDragSession();
+}
+
+static void dragSourceHandleAction(void* data, struct wl_data_source* source,
+                                   uint32_t action) { (void)data; (void)source; (void)action; }
+
+static const struct wl_data_source_listener dragSourceListener =
+{
+    dragSourceHandleTarget,
+    dragSourceHandleSend,
+    dragSourceHandleCancelled,
+    dragSourceHandleDndDropPerformed,
+    dragSourceHandleDndFinished,
+    dragSourceHandleAction,
+};
+
+// Start a self-initiated toplevel drag using xdg_toplevel_drag_v1. Returns
+// GLFW_TRUE on success; caller should fall back to xdg_toplevel.move otherwise.
+// The critical property of this path vs plain move: the compositor delivers
+// wl_data_device enter/motion/leave events to our surfaces under the cursor,
+// so the application can detect drop targets (e.g. dock regions) while the
+// dragged window follows the cursor.
+static GLFWbool startToplevelDragSession(_GLFWwindow* window, uint32_t serial)
+{
+    if (!_glfw.wl.toplevelDragManager ||
+        !_glfw.wl.dataDeviceManager ||
+        !_glfw.wl.dataDevice)
+    {
+        return GLFW_FALSE;
+    }
+
+    struct xdg_toplevel* toplevel = window->wl.xdg.toplevel;
+    if (!toplevel && window->wl.libdecor.frame)
+        toplevel = libdecor_frame_get_xdg_toplevel(window->wl.libdecor.frame);
+    if (!toplevel)
+        return GLFW_FALSE;
+
+    // One session at a time. If we're already in a drag, end it first.
+    if (_glfw.wl.toplevelDragSession.source)
+        endToplevelDragSession();
+
+    struct wl_data_source* source =
+        wl_data_device_manager_create_data_source(_glfw.wl.dataDeviceManager);
+    if (!source)
+        return GLFW_FALSE;
+    wl_data_source_add_listener(source, &dragSourceListener, NULL);
+    wl_data_source_offer(source, GLFW_WAYLAND_WINDOW_DRAG_MIME);
+
+    // Advertise "move" as the DnD action. Without negotiated actions the
+    // compositor (on v3+) won't deliver dnd_drop_performed / dnd_finished,
+    // leaving the drag in a half-completed state after the user releases.
+    if (wl_data_source_get_version(source) >= 3)
+    {
+        wl_data_source_set_actions(source,
+            WL_DATA_DEVICE_MANAGER_DND_ACTION_MOVE);
+    }
+
+    struct xdg_toplevel_drag_v1* drag =
+        xdg_toplevel_drag_manager_v1_get_xdg_toplevel_drag(
+            _glfw.wl.toplevelDragManager, source);
+    if (!drag)
+    {
+        wl_data_source_destroy(source);
+        return GLFW_FALSE;
+    }
+
+    _glfw.wl.toplevelDragSession.source = source;
+    _glfw.wl.toplevelDragSession.drag = drag;
+    _glfw.wl.toplevelDragSession.window = window;
+
+    // Per spec, when the dragged toplevel is already mapped (our case, since
+    // we only reach here after the window is mapped) attach() must come
+    // before start_drag(). The offset hints where the cursor hotspot should
+    // sit relative to the toplevel's top-left in surface-local coords —
+    // passing (0, 0) snaps the window so the cursor is in its top-left
+    // corner.
+    //
+    // Two cases:
+    //  - Dragging the window that received the press (regular titlebar
+    //    drag): use that window's own tracked cursor position.
+    //  - Tab-tear: the press happened on a different window (e.g. main
+    //    window's tab bar), then a new toplevel was created under the
+    //    cursor. The new toplevel hasn't received any motion events yet, so
+    //    its cursorPosX/Y is 0, which is why it grabs from the top-left.
+    //    Compute the cursor position inside the new window as the source
+    //    window's cursor pos minus the new window's caller-intended
+    //    position (ImGui wrote this via glfwSetWindowPos before show).
+    int offsetX = 0;
+    int offsetY = 0;
+    if (_glfw.wl.pointerButtonSurface == window->wl.surface)
+    {
+        offsetX = (int) window->wl.cursorPosX;
+        offsetY = (int) window->wl.cursorPosY;
+    }
+    else if (_glfw.wl.pointerButtonSurface &&
+             wl_proxy_get_tag((struct wl_proxy*) _glfw.wl.pointerButtonSurface)
+                 == &_glfw.wl.tag)
+    {
+        _GLFWwindow* src =
+            wl_surface_get_user_data(_glfw.wl.pointerButtonSurface);
+        if (src)
+        {
+            offsetX = (int)(src->wl.cursorPosX - window->wl.pendingPosX);
+            offsetY = (int)(src->wl.cursorPosY - window->wl.pendingPosY);
+        }
+    }
+    if (offsetX < 0) offsetX = 0;
+    if (offsetY < 0) offsetY = 0;
+    xdg_toplevel_drag_v1_attach(drag, toplevel, offsetX, offsetY);
+
+    struct wl_surface* origin = _glfw.wl.pointerButtonSurface;
+    if (!origin)
+        origin = window->wl.surface;
+    wl_data_device_start_drag(_glfw.wl.dataDevice, source,
+                              origin, NULL, serial);
+    return GLFW_TRUE;
+}
+
 void _glfwDragWindowWayland(_GLFWwindow* window)
 {
     if (!_glfw.wl.seat || !_glfw.wl.pointerButtonSerial)
         return;
 
-    // Fire immediately when the toplevel is already mapped; otherwise stash
-    // the press serial and let the mapped-frame callback issue the move once
-    // the compositor has processed the first buffer. The pre-show case
-    // matters for tab-tear (caller invokes this before glfwShowWindow maps
-    // anything), and the pre-map case matters because calling
-    // xdg_toplevel.move on an unmapped surface crashes KWin.
+    // A drag session is already in flight for this window — no-op. ImGui's
+    // Platform_SetWindowPos fires each frame during its drag math, but we
+    // only want to hand the drag to the compositor once per user press.
+    if (_glfw.wl.toplevelDragSession.source &&
+        _glfw.wl.toplevelDragSession.window == window)
+    {
+        return;
+    }
+
+    // Pre-map: stash the request and let the mapped-frame callback fire it
+    // once the compositor has processed the first buffer. Calling
+    // xdg_toplevel.move (or starting a drag attached to an unmapped toplevel)
+    // on an unmapped surface has been observed to crash KWin. The pre-show
+    // case matters for tab-tear (caller invokes this before glfwShowWindow
+    // maps anything).
     if (!window->wl.mapped)
     {
         window->wl.dragPendingSerial = _glfw.wl.pointerButtonSerial;
@@ -3265,6 +3543,14 @@ void _glfwDragWindowWayland(_GLFWwindow* window)
         return;
     }
 
+    // Preferred path: xdg_toplevel_drag_v1 (staging) — same visual effect as
+    // xdg_toplevel.move but the compositor keeps delivering DnD events to
+    // our surfaces under the cursor. That's what lets the dock system see
+    // the dragged window passing over drop targets.
+    if (startToplevelDragSession(window, _glfw.wl.pointerButtonSerial))
+        return;
+
+    // Fallback for compositors that don't advertise the manager global.
     struct xdg_toplevel* toplevel = window->wl.xdg.toplevel;
     if (!toplevel && window->wl.libdecor.frame)
         toplevel = libdecor_frame_get_xdg_toplevel(window->wl.libdecor.frame);
@@ -3272,6 +3558,13 @@ void _glfwDragWindowWayland(_GLFWwindow* window)
         return;
 
     xdg_toplevel_move(toplevel, _glfw.wl.seat, _glfw.wl.pointerButtonSerial);
+
+    // xdg_toplevel.move swallows the release event, so synthesize one now so
+    // the application's input state doesn't stay stuck in "button held" after
+    // the move ends.
+    if (_glfw.wl.pointerButtonsDown > 0)
+        _glfw.wl.pointerButtonsDown--;
+    _glfwInputMouseClick(window, GLFW_MOUSE_BUTTON_LEFT, GLFW_RELEASE, 0);
 }
 
 void _glfwSetWindowMonitorWayland(_GLFWwindow* window,

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -1569,7 +1569,30 @@ static void processPointerButton(int button, int action)
 {
     _GLFWwindow* window = wl_surface_get_user_data(_glfw.wl.pointerSurface);
     if (window->wl.surface == _glfw.wl.pointerSurface)
+    {
+        // For undecorated windows, check titlebar hit test on left-click
+        // to initiate compositor-driven window drag (mirrors the X11 path)
+        if (button == GLFW_MOUSE_BUTTON_LEFT && action == GLFW_PRESS && !window->decorated)
+        {
+            int titlebarHit = 0;
+            _glfwInputTitleBarHitTest(window, (int) window->wl.cursorPosX, (int) window->wl.cursorPosY, &titlebarHit);
+
+            if (titlebarHit)
+            {
+                struct xdg_toplevel* toplevel = window->wl.xdg.toplevel;
+                if (window->wl.libdecor.frame)
+                    toplevel = libdecor_frame_get_xdg_toplevel(window->wl.libdecor.frame);
+
+                if (toplevel)
+                {
+                    xdg_toplevel_move(toplevel, _glfw.wl.seat, _glfw.wl.serial);
+                    return;
+                }
+            }
+        }
+
         _glfwInputMouseClick(window, button, action, _glfw.wl.xkb.modifiers);
+    }
     else
     {
         if (window->wl.fallback.decorations)

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -1247,6 +1247,155 @@ static void updateXdgSizeLimits(_GLFWwindow* window)
     xdg_toplevel_set_max_size(window->wl.xdg.toplevel, maxwidth, maxheight);
 }
 
+static void xdgPopupSurfaceHandleConfigure(void* userData,
+                                           struct xdg_surface* surface,
+                                           uint32_t serial)
+{
+    // Popups don't go through the toplevel state machine, so just ACK the
+    // configure and mark the window as visible. Size is already known from
+    // the positioner we handed to the compositor at creation.
+    _GLFWwindow* window = userData;
+    xdg_surface_ack_configure(surface, serial);
+
+    if (!window->wl.visible)
+    {
+        window->wl.visible = GLFW_TRUE;
+        _glfwInputWindowDamage(window);
+    }
+}
+
+static const struct xdg_surface_listener xdgPopupSurfaceListener =
+{
+    xdgPopupSurfaceHandleConfigure
+};
+
+static void xdgPopupHandleConfigure(void* userData,
+                                    struct xdg_popup* popup,
+                                    int32_t x, int32_t y,
+                                    int32_t width, int32_t height)
+{
+    // Compositor-confirmed popup geometry. ImGui already has its own layout,
+    // so nothing to propagate here beyond the surface-level size sync.
+    _GLFWwindow* window = userData;
+    if (width > 0 && height > 0 &&
+        (width != window->wl.width || height != window->wl.height))
+    {
+        window->wl.width = width;
+        window->wl.height = height;
+        resizeFramebuffer(window);
+        _glfwInputWindowSize(window, width, height);
+    }
+}
+
+static void xdgPopupHandlePopupDone(void* userData, struct xdg_popup* popup)
+{
+    // Compositor dismissed the popup (e.g. user clicked outside). Ask the
+    // owning application to close the window; ImGui will tear down the viewport.
+    _GLFWwindow* window = userData;
+    _glfwInputWindowCloseRequest(window);
+}
+
+static void xdgPopupHandleRepositioned(void* userData,
+                                       struct xdg_popup* popup,
+                                       uint32_t token)
+{
+    // Unused: we don't currently issue xdg_popup.reposition requests.
+}
+
+static const struct xdg_popup_listener xdgPopupListener =
+{
+    xdgPopupHandleConfigure,
+    xdgPopupHandlePopupDone,
+    xdgPopupHandleRepositioned,
+};
+
+// Resolve the xdg_surface of a window that owns a mapped toplevel, whether
+// created directly via xdg-shell or wrapped by libdecor. Returns NULL if the
+// window has no queryable xdg_surface (libdecor < 0.2 lacks the accessor).
+static struct xdg_surface* getWindowXdgSurface(_GLFWwindow* w)
+{
+    if (w->wl.xdg.surface)
+        return w->wl.xdg.surface;
+    if (w->wl.libdecor.frame && _glfw.wl.libdecor.libdecor_frame_get_xdg_surface_)
+        return libdecor_frame_get_xdg_surface(w->wl.libdecor.frame);
+    return NULL;
+}
+
+// Walk the GLFW window list and return the first window that owns a mapped
+// xdg_toplevel (directly or through libdecor) and has a queryable xdg_surface.
+// That window acts as the parent surface for any popup we spawn.
+static _GLFWwindow* findWaylandPopupParent(_GLFWwindow* self)
+{
+    for (_GLFWwindow* w = _glfw.windowListHead; w; w = w->next)
+    {
+        if (w == self) continue;
+        if (w->wl.xdg.popup) continue;
+        if (!getWindowXdgSurface(w)) continue;
+        if (w->wl.xdg.toplevel || w->wl.libdecor.frame)
+            return w;
+    }
+    return NULL;
+}
+
+static GLFWbool createXdgPopupShellObjects(_GLFWwindow* window,
+                                           _GLFWwindow* parent)
+{
+    window->wl.xdg.surface = xdg_wm_base_get_xdg_surface(_glfw.wl.wmBase,
+                                                         window->wl.surface);
+    if (!window->wl.xdg.surface)
+    {
+        _glfwInputError(GLFW_PLATFORM_ERROR,
+                        "Wayland: Failed to create xdg-surface for popup");
+        return GLFW_FALSE;
+    }
+    xdg_surface_add_listener(window->wl.xdg.surface, &xdgPopupSurfaceListener, window);
+
+    struct xdg_positioner* positioner =
+        xdg_wm_base_create_positioner(_glfw.wl.wmBase);
+    if (!positioner)
+    {
+        _glfwInputError(GLFW_PLATFORM_ERROR,
+                        "Wayland: Failed to create xdg-positioner for popup");
+        return GLFW_FALSE;
+    }
+
+    const int w = window->wl.width  > 0 ? window->wl.width  : 1;
+    const int h = window->wl.height > 0 ? window->wl.height : 1;
+    xdg_positioner_set_size(positioner, w, h);
+
+    // Treat the coords handed to glfwSetWindowPos as parent-relative, because
+    // on Wayland there is no global coordinate space. ImGui's main viewport
+    // lives at (0, 0) in its own space, so menus/tooltips positioned against
+    // it already carry correct parent-relative offsets.
+    const int px = window->wl.pendingPosSet ? window->wl.pendingPosX : 0;
+    const int py = window->wl.pendingPosSet ? window->wl.pendingPosY : 0;
+    xdg_positioner_set_anchor_rect(positioner, px, py, 1, 1);
+    xdg_positioner_set_anchor(positioner, XDG_POSITIONER_ANCHOR_TOP_LEFT);
+    xdg_positioner_set_gravity(positioner, XDG_POSITIONER_GRAVITY_BOTTOM_RIGHT);
+    xdg_positioner_set_constraint_adjustment(positioner,
+        XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_SLIDE_X |
+        XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_SLIDE_Y |
+        XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_X |
+        XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_Y);
+
+    window->wl.xdg.popup = xdg_surface_get_popup(window->wl.xdg.surface,
+                                                 getWindowXdgSurface(parent),
+                                                 positioner);
+    xdg_positioner_destroy(positioner);
+
+    if (!window->wl.xdg.popup)
+    {
+        _glfwInputError(GLFW_PLATFORM_ERROR,
+                        "Wayland: Failed to create xdg-popup");
+        return GLFW_FALSE;
+    }
+    xdg_popup_add_listener(window->wl.xdg.popup, &xdgPopupListener, window);
+
+    wl_surface_commit(window->wl.surface);
+    wl_display_roundtrip(_glfw.wl.display);
+    return GLFW_TRUE;
+}
+
 static GLFWbool createXdgShellObjects(_GLFWwindow* window)
 {
     window->wl.xdg.surface = xdg_wm_base_get_xdg_surface(_glfw.wl.wmBase,
@@ -1321,6 +1470,19 @@ static GLFWbool createXdgShellObjects(_GLFWwindow* window)
 
 static GLFWbool createShellObjects(_GLFWwindow* window)
 {
+    // Treat ImGui-style transient viewports as xdg_popups so they appear
+    // relative to the main window on Wayland (toplevel positioning is
+    // protocol-forbidden). The signal is `createdUnfocused` — ImGui's GLFW
+    // backend unconditionally sets GLFW_FOCUSED=false for viewport windows,
+    // whereas app-created toplevels (splash, main editor) leave the default
+    // `true`, so they stay as real toplevels.
+    if (window->wl.createdUnfocused && !window->decorated && !window->monitor)
+    {
+        _GLFWwindow* parent = findWaylandPopupParent(window);
+        if (parent)
+            return createXdgPopupShellObjects(window, parent);
+    }
+
     if (_glfw.wl.libdecor.context)
     {
         if (createLibdecorFrame(window))
@@ -1340,6 +1502,9 @@ static void destroyShellObjects(_GLFWwindow* window)
     if (window->wl.xdg.decoration)
         zxdg_toplevel_decoration_v1_destroy(window->wl.xdg.decoration);
 
+    if (window->wl.xdg.popup)
+        xdg_popup_destroy(window->wl.xdg.popup);
+
     if (window->wl.xdg.toplevel)
         xdg_toplevel_destroy(window->wl.xdg.toplevel);
 
@@ -1349,6 +1514,7 @@ static void destroyShellObjects(_GLFWwindow* window)
     window->wl.libdecor.frame = NULL;
     window->wl.xdg.decoration = NULL;
     window->wl.xdg.decorationMode = 0;
+    window->wl.xdg.popup = NULL;
     window->wl.xdg.toplevel = NULL;
     window->wl.xdg.surface = NULL;
 }
@@ -2581,6 +2747,8 @@ GLFWbool _glfwCreateWindowWayland(_GLFWwindow* window,
                                   const _GLFWctxconfig* ctxconfig,
                                   const _GLFWfbconfig* fbconfig)
 {
+    window->wl.createdUnfocused = !wndconfig->focused;
+
     if (!createNativeSurface(window, wndconfig, fbconfig))
         return GLFW_FALSE;
 
@@ -2727,19 +2895,31 @@ void _glfwSetWindowIconWayland(_GLFWwindow* window,
 
 void _glfwGetWindowPosWayland(_GLFWwindow* window, int* xpos, int* ypos)
 {
-    // A Wayland client is not aware of its position, so just warn and leave it
-    // as (0, 0)
-
-    _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
-                    "Wayland: The platform does not provide the window position");
+    // A Wayland client is not aware of its global position. For popup windows
+    // we do know the requested parent-relative anchor we were created at, so
+    // report that; for toplevels, there's no meaningful value to return.
+    //
+    // Stay silent: ImGui's viewport code polls this every frame and the
+    // warning would flood the log.
+    if (window->wl.pendingPosSet)
+    {
+        if (xpos) *xpos = window->wl.pendingPosX;
+        if (ypos) *ypos = window->wl.pendingPosY;
+    }
 }
 
 void _glfwSetWindowPosWayland(_GLFWwindow* window, int xpos, int ypos)
 {
-    // A Wayland client can not set its position, so just warn
+    if (!window->wl.xdg.surface && !window->wl.libdecor.frame)
+    {
+        window->wl.pendingPosX = xpos;
+        window->wl.pendingPosY = ypos;
+        window->wl.pendingPosSet = GLFW_TRUE;
+        return;
+    }
 
     _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
-                    "Wayland: The platform does not support setting the window position");
+                    "Wayland: The platform does not support setting the window position after it has been mapped");
 }
 
 void _glfwGetWindowSizeWayland(_GLFWwindow* window, int* width, int* height)
@@ -2916,7 +3096,7 @@ void _glfwMaximizeWindowWayland(_GLFWwindow* window)
 
 void _glfwShowWindowWayland(_GLFWwindow* window)
 {
-    if (!window->wl.libdecor.frame && !window->wl.xdg.toplevel)
+    if (!window->wl.libdecor.frame && !window->wl.xdg.toplevel && !window->wl.xdg.popup)
     {
         // NOTE: The XDG surface and role are created here so command-line applications
         //       with off-screen windows do not appear in for example the Unity dock

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -1481,20 +1481,25 @@ static struct xdg_surface* getWindowXdgSurface(_GLFWwindow* w)
     return NULL;
 }
 
-// Walk the GLFW window list and return the first window that owns a mapped
-// xdg_toplevel (directly or through libdecor) and has a queryable xdg_surface.
-// That window acts as the parent surface for any popup we spawn.
+// Resolve the parent surface for a popup we are about to spawn. A nested popup
+// (e.g. a submenu) must parent to the topmost mapped popup, not the root
+// toplevel: Wayland requires an xdg_popup's parent be the topmost surface in
+// the popup stack. The window list is newest-first (glfwCreateWindow prepends
+// to windowListHead), so the first popup we encounter is the topmost; if none
+// is open, fall back to the first mapped toplevel.
 static _GLFWwindow* findWaylandPopupParent(_GLFWwindow* self)
 {
+    _GLFWwindow* toplevel = NULL;
     for (_GLFWwindow* w = _glfw.windowListHead; w; w = w->next)
     {
         if (w == self) continue;
-        if (w->wl.xdg.popup) continue;
         if (!getWindowXdgSurface(w)) continue;
-        if (w->wl.xdg.toplevel || w->wl.libdecor.frame)
+        if (w->wl.xdg.popup)
             return w;
+        if ((w->wl.xdg.toplevel || w->wl.libdecor.frame) && !toplevel)
+            toplevel = w;
     }
-    return NULL;
+    return toplevel;
 }
 
 static GLFWbool createXdgPopupShellObjects(_GLFWwindow* window,
@@ -1523,9 +1528,16 @@ static GLFWbool createXdgPopupShellObjects(_GLFWwindow* window,
     const int h = window->wl.height > 0 ? window->wl.height : 1;
     xdg_positioner_set_size(positioner, w, h);
 
-    // pendingPos is parent-relative (no global coords on Wayland).
-    const int px = window->wl.pendingPosSet ? window->wl.pendingPosX : 0;
-    const int py = window->wl.pendingPosSet ? window->wl.pendingPosY : 0;
+    // The anchor rect is relative to the parent surface (no global coords on
+    // Wayland). Window positions are given in one global frame rooted at the
+    // toplevel, so when the parent is itself a popup, rebase onto its origin.
+    int px = window->wl.pendingPosSet ? window->wl.pendingPosX : 0;
+    int py = window->wl.pendingPosSet ? window->wl.pendingPosY : 0;
+    if (window->wl.pendingPosSet && parent->wl.xdg.popup && parent->wl.pendingPosSet)
+    {
+        px -= parent->wl.pendingPosX;
+        py -= parent->wl.pendingPosY;
+    }
     xdg_positioner_set_anchor_rect(positioner, px, py, 1, 1);
     xdg_positioner_set_anchor(positioner, XDG_POSITIONER_ANCHOR_TOP_LEFT);
     xdg_positioner_set_gravity(positioner, XDG_POSITIONER_GRAVITY_BOTTOM_RIGHT);
@@ -1547,6 +1559,7 @@ static GLFWbool createXdgPopupShellObjects(_GLFWwindow* window,
         return GLFW_FALSE;
     }
     xdg_popup_add_listener(window->wl.xdg.popup, &xdgPopupListener, window);
+    window->wl.xdg.popupParent = parent;
 
     // Grab with a press serial so the compositor auto-dismisses on outside click.
     if (_glfw.wl.seat && _glfw.wl.pointerButtonSerial)
@@ -1731,6 +1744,18 @@ static GLFWbool createShellObjects(_GLFWwindow* window)
 
 static void destroyShellObjects(_GLFWwindow* window)
 {
+    // Wayland requires popups be destroyed topmost-first (LIFO). Callers may
+    // tear popup chains down parent-first, so before destroying our own popup,
+    // recursively destroy any child popups still parented to this window.
+    if (window->wl.xdg.popup)
+    {
+        for (_GLFWwindow* w = _glfw.windowListHead; w; w = w->next)
+        {
+            if (w != window && w->wl.xdg.popupParent == window && w->wl.xdg.popup)
+                destroyShellObjects(w);
+        }
+    }
+
     destroyKdeShadow(window);
     destroyFallbackDecorations(window);
 
@@ -1756,6 +1781,7 @@ static void destroyShellObjects(_GLFWwindow* window)
     window->wl.xdg.decoration = NULL;
     window->wl.xdg.decorationMode = 0;
     window->wl.xdg.popup = NULL;
+    window->wl.xdg.popupParent = NULL;
     window->wl.xdg.toplevel = NULL;
     window->wl.xdg.surface = NULL;
     window->wl.mappedCallback = NULL;
@@ -3254,6 +3280,13 @@ void _glfwDestroyWindowWayland(_GLFWwindow* window)
 
     if (window->wl.surface == _glfw.wl.pointerSurface)
         _glfw.wl.pointerSurface = NULL;
+
+    // Drop any popup's back-reference to this window so it can't dangle.
+    for (_GLFWwindow* w = _glfw.windowListHead; w; w = w->next)
+    {
+        if (w->wl.xdg.popupParent == window)
+            w->wl.xdg.popupParent = NULL;
+    }
 
     if (window == _glfw.wl.keyboardFocus)
     {

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -1481,23 +1481,28 @@ static struct xdg_surface* getWindowXdgSurface(_GLFWwindow* w)
     return NULL;
 }
 
-// Resolve the parent surface for a popup we are about to spawn. A nested popup
-// (e.g. a submenu) must parent to the topmost mapped popup, not the root
-// toplevel: Wayland requires an xdg_popup's parent be the topmost surface in
-// the popup stack. The window list is newest-first (glfwCreateWindow prepends
-// to windowListHead), so the first popup we encounter is the topmost; if none
-// is open, fall back to the first mapped toplevel.
+// Resolve the parent surface for a popup we are about to spawn. Wayland requires
+// an xdg_popup's parent be the topmost surface in the popup stack, so a nested
+// popup (e.g. a submenu) must parent to the topmost mapped popup rather than the
+// root toplevel. The window list is newest-first (glfwCreateWindow prepends to
+// windowListHead), which is why iterating front-to-back finds the topmost first.
 static _GLFWwindow* findWaylandPopupParent(_GLFWwindow* self)
 {
+    _GLFWwindow* toplevel = NULL;
     for (_GLFWwindow* w = _glfw.windowListHead; w; w = w->next)
     {
         if (w == self) continue;
-        if (w->wl.xdg.popup) continue;
         if (!getWindowXdgSurface(w)) continue;
-        if (w->wl.xdg.toplevel || w->wl.libdecor.frame)
+
+        // Return newest popup older than self
+        if (w->wl.xdg.popup)
             return w;
+
+        // If no newest popup older than self exists, we will return the newest mapped toplevel
+        if ((w->wl.xdg.toplevel || w->wl.libdecor.frame) && !toplevel)
+            toplevel = w;
     }
-    return NULL;
+    return toplevel;
 }
 
 static GLFWbool createXdgPopupShellObjects(_GLFWwindow* window,
@@ -1531,7 +1536,7 @@ static GLFWbool createXdgPopupShellObjects(_GLFWwindow* window,
     // toplevel, so when the parent is itself a popup, rebase onto its origin.
     int px = window->wl.pendingPosSet ? window->wl.pendingPosX : 0;
     int py = window->wl.pendingPosSet ? window->wl.pendingPosY : 0;
-    if (parent->wl.xdg.popup && parent->wl.pendingPosSet)
+    if (window->wl.pendingPosSet && parent->wl.xdg.popup && parent->wl.pendingPosSet)
     {
         px -= parent->wl.pendingPosX;
         py -= parent->wl.pendingPosY;
@@ -3277,13 +3282,6 @@ void _glfwDestroyWindowWayland(_GLFWwindow* window)
     if (window->wl.surface == _glfw.wl.pointerSurface)
         _glfw.wl.pointerSurface = NULL;
 
-    // Drop any popup's back-reference to this window so it can't dangle.
-    for (_GLFWwindow* w = _glfw.windowListHead; w; w = w->next)
-    {
-        if (w->popupParent == window)
-            w->popupParent = NULL;
-    }
-
     if (window == _glfw.wl.keyboardFocus)
     {
         struct itimerspec timer = {0};
@@ -3317,6 +3315,16 @@ void _glfwDestroyWindowWayland(_GLFWwindow* window)
         window->context.destroy(window);
 
     destroyShellObjects(window);
+
+    // Drop any popup's back-reference to this window so it can't dangle. Must
+    // run after destroyShellObjects: its LIFO child-popup teardown locates
+    // children via popupParent, so clearing the links any earlier would let a
+    // parent popup be destroyed before its child (a Wayland protocol error).
+    for (_GLFWwindow* w = _glfw.windowListHead; w; w = w->next)
+    {
+        if (w->popupParent == window)
+            w->popupParent = NULL;
+    }
 
     if (window->wl.fallback.buffer)
         wl_buffer_destroy(window->wl.fallback.buffer);

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -2140,7 +2140,7 @@ static void processPointerMotion(double xpos, double ypos)
     }
 }
 
-static void processPointerButton(int button, int action)
+static void processPointerButton(int button, int action, uint32_t time)
 {
     // Compositor sends a spurious release when transferring the grab to drag-and-drop.
     // Suppress it; endToplevelDragSession synthesizes the real release.
@@ -2190,8 +2190,26 @@ static void processPointerButton(int button, int action)
                     _glfwInputTitleBarHitTest(window, x, y, &titlebarHit);
                     if (titlebarHit)
                     {
-                        xdg_toplevel_move(toplevel, _glfw.wl.seat, _glfw.wl.serial);
-                        handled = GLFW_TRUE;
+                        const uint32_t doubleClickMs = 400;
+
+                        if (_glfw.wl.titlebarClickWindow == window &&
+                            time - _glfw.wl.titlebarClickTime <= doubleClickMs)
+                        {
+                            _glfw.wl.titlebarClickTime = 0;
+                            _glfw.wl.titlebarClickWindow = NULL;
+                            if (window->wl.maximized)
+                                _glfwRestoreWindowWayland(window);
+                            else
+                                _glfwMaximizeWindowWayland(window);
+                            handled = GLFW_TRUE;
+                        }
+                        else
+                        {
+                            _glfw.wl.titlebarClickTime = time;
+                            _glfw.wl.titlebarClickWindow = window;
+                            xdg_toplevel_move(toplevel, _glfw.wl.seat, _glfw.wl.serial);
+                            handled = GLFW_TRUE;
+                        }
                     }
                 }
             }
@@ -2351,9 +2369,10 @@ static void pointerHandleButton(void* userData,
         _glfw.wl.pending.events |= GLFW_PENDING_BUTTON;
         _glfw.wl.pending.button = button;
         _glfw.wl.pending.action = action;
+        _glfw.wl.pending.buttonTime = time;
     }
     else
-        processPointerButton(button, action);
+        processPointerButton(button, action, time);
 }
 
 static void pointerHandleAxis(void* userData,
@@ -2401,7 +2420,7 @@ static void pointerHandleFrame(void* userData, struct wl_pointer* pointer)
         processPointerMotion(_glfw.wl.pending.pointerX, _glfw.wl.pending.pointerY);
 
     if (_glfw.wl.pending.events & GLFW_PENDING_BUTTON)
-        processPointerButton(_glfw.wl.pending.button, _glfw.wl.pending.action);
+        processPointerButton(_glfw.wl.pending.button, _glfw.wl.pending.action, _glfw.wl.pending.buttonTime);
 
     if (_glfw.wl.pending.events & GLFW_PENDING_DISCRETE)
         processPointerScroll(_glfw.wl.pending.discreteX, _glfw.wl.pending.discreteY);

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -4004,8 +4004,16 @@ void _glfwGetCursorPosWayland(_GLFWwindow* window, double* xpos, double* ypos)
 
 void _glfwSetCursorPosWayland(_GLFWwindow* window, double x, double y)
 {
-    _glfwInputError(GLFW_FEATURE_UNAVAILABLE,
-                    "Wayland: The platform does not support setting the cursor position");
+    if (window->wl.lockedPointer)
+    {
+        window->wl.cursorPosHintSet = GLFW_TRUE;
+        window->wl.cursorPosHintX = x;
+        window->wl.cursorPosHintY = y;
+        zwp_locked_pointer_v1_set_cursor_position_hint(
+            window->wl.lockedPointer,
+            wl_fixed_from_double(x),
+            wl_fixed_from_double(y));
+    }
 }
 
 void _glfwSetCursorModeWayland(_GLFWwindow* window, int mode)
@@ -4215,6 +4223,17 @@ static void unlockPointer(_GLFWwindow* window)
 {
     zwp_relative_pointer_v1_destroy(window->wl.relativePointer);
     window->wl.relativePointer = NULL;
+
+    if (window->wl.cursorPosHintSet)
+    {
+        zwp_locked_pointer_v1_set_cursor_position_hint(
+            window->wl.lockedPointer,
+            wl_fixed_from_double(window->wl.cursorPosHintX),
+            wl_fixed_from_double(window->wl.cursorPosHintY));
+        wl_surface_commit(window->wl.surface);
+        wl_display_flush(_glfw.wl.display);
+        window->wl.cursorPosHintSet = GLFW_FALSE;
+    }
 
     zwp_locked_pointer_v1_destroy(window->wl.lockedPointer);
     window->wl.lockedPointer = NULL;

--- a/src/wl_window.c
+++ b/src/wl_window.c
@@ -1489,17 +1489,15 @@ static struct xdg_surface* getWindowXdgSurface(_GLFWwindow* w)
 // is open, fall back to the first mapped toplevel.
 static _GLFWwindow* findWaylandPopupParent(_GLFWwindow* self)
 {
-    _GLFWwindow* toplevel = NULL;
     for (_GLFWwindow* w = _glfw.windowListHead; w; w = w->next)
     {
         if (w == self) continue;
+        if (w->wl.xdg.popup) continue;
         if (!getWindowXdgSurface(w)) continue;
-        if (w->wl.xdg.popup)
+        if (w->wl.xdg.toplevel || w->wl.libdecor.frame)
             return w;
-        if ((w->wl.xdg.toplevel || w->wl.libdecor.frame) && !toplevel)
-            toplevel = w;
     }
-    return toplevel;
+    return NULL;
 }
 
 static GLFWbool createXdgPopupShellObjects(_GLFWwindow* window,
@@ -1533,7 +1531,7 @@ static GLFWbool createXdgPopupShellObjects(_GLFWwindow* window,
     // toplevel, so when the parent is itself a popup, rebase onto its origin.
     int px = window->wl.pendingPosSet ? window->wl.pendingPosX : 0;
     int py = window->wl.pendingPosSet ? window->wl.pendingPosY : 0;
-    if (window->wl.pendingPosSet && parent->wl.xdg.popup && parent->wl.pendingPosSet)
+    if (parent->wl.xdg.popup && parent->wl.pendingPosSet)
     {
         px -= parent->wl.pendingPosX;
         py -= parent->wl.pendingPosY;
@@ -1543,9 +1541,7 @@ static GLFWbool createXdgPopupShellObjects(_GLFWwindow* window,
     xdg_positioner_set_gravity(positioner, XDG_POSITIONER_GRAVITY_BOTTOM_RIGHT);
     xdg_positioner_set_constraint_adjustment(positioner,
         XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_SLIDE_X |
-        XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_SLIDE_Y |
-        XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_X |
-        XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_Y);
+        XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_SLIDE_Y);
 
     window->wl.xdg.popup = xdg_surface_get_popup(window->wl.xdg.surface,
                                                  getWindowXdgSurface(parent),
@@ -1559,7 +1555,6 @@ static GLFWbool createXdgPopupShellObjects(_GLFWwindow* window,
         return GLFW_FALSE;
     }
     xdg_popup_add_listener(window->wl.xdg.popup, &xdgPopupListener, window);
-    window->wl.xdg.popupParent = parent;
 
     // Grab with a press serial so the compositor auto-dismisses on outside click.
     if (_glfw.wl.seat && _glfw.wl.pointerButtonSerial)
@@ -1721,7 +1716,9 @@ static GLFWbool createShellObjects(_GLFWwindow* window)
     // Menu-style windows (undecorated + !focusOnShow) become xdg_popups.
     if (!window->focusOnShow && !window->decorated && !window->monitor)
     {
-        _GLFWwindow* parent = findWaylandPopupParent(window);
+        _GLFWwindow* parent = window->popupParent
+            ? window->popupParent
+            : findWaylandPopupParent(window);
         if (parent)
             return createXdgPopupShellObjects(window, parent);
     }
@@ -1751,7 +1748,7 @@ static void destroyShellObjects(_GLFWwindow* window)
     {
         for (_GLFWwindow* w = _glfw.windowListHead; w; w = w->next)
         {
-            if (w != window && w->wl.xdg.popupParent == window && w->wl.xdg.popup)
+            if (w != window && w->popupParent == window && w->wl.xdg.popup)
                 destroyShellObjects(w);
         }
     }
@@ -1781,7 +1778,6 @@ static void destroyShellObjects(_GLFWwindow* window)
     window->wl.xdg.decoration = NULL;
     window->wl.xdg.decorationMode = 0;
     window->wl.xdg.popup = NULL;
-    window->wl.xdg.popupParent = NULL;
     window->wl.xdg.toplevel = NULL;
     window->wl.xdg.surface = NULL;
     window->wl.mappedCallback = NULL;
@@ -3284,8 +3280,8 @@ void _glfwDestroyWindowWayland(_GLFWwindow* window)
     // Drop any popup's back-reference to this window so it can't dangle.
     for (_GLFWwindow* w = _glfw.windowListHead; w; w = w->next)
     {
-        if (w->wl.xdg.popupParent == window)
-            w->wl.xdg.popupParent = NULL;
+        if (w->popupParent == window)
+            w->popupParent = NULL;
     }
 
     if (window == _glfw.wl.keyboardFocus)

--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -1226,6 +1226,7 @@ GLFWbool _glfwConnectX11(int platformID, _GLFWplatform* platform)
         .hideWindow = _glfwHideWindowX11,
         .requestWindowAttention = _glfwRequestWindowAttentionX11,
         .focusWindow = _glfwFocusWindowX11,
+        .dragWindow = _glfwDragWindowX11,
         .setWindowMonitor = _glfwSetWindowMonitorX11,
         .windowFocused = _glfwWindowFocusedX11,
         .windowIconified = _glfwWindowIconifiedX11,

--- a/src/x11_init.c
+++ b/src/x11_init.c
@@ -580,6 +580,8 @@ static void detectEWMH(void)
         getAtomIfSupported(supportedAtoms, atomCount, "_NET_WM_STATE_MAXIMIZED_HORZ");
     _glfw.x11.NET_WM_STATE_DEMANDS_ATTENTION =
         getAtomIfSupported(supportedAtoms, atomCount, "_NET_WM_STATE_DEMANDS_ATTENTION");
+    _glfw.x11.NET_WM_STATE_SKIP_TASKBAR =
+        getAtomIfSupported(supportedAtoms, atomCount, "_NET_WM_STATE_SKIP_TASKBAR");
     _glfw.x11.NET_WM_FULLSCREEN_MONITORS =
         getAtomIfSupported(supportedAtoms, atomCount, "_NET_WM_FULLSCREEN_MONITORS");
     _glfw.x11.NET_WM_WINDOW_TYPE =

--- a/src/x11_platform.h
+++ b/src/x11_platform.h
@@ -921,6 +921,7 @@ void _glfwShowWindowX11(_GLFWwindow* window);
 void _glfwHideWindowX11(_GLFWwindow* window);
 void _glfwRequestWindowAttentionX11(_GLFWwindow* window);
 void _glfwFocusWindowX11(_GLFWwindow* window);
+void _glfwDragWindowX11(_GLFWwindow* window);
 void _glfwSetWindowMonitorX11(_GLFWwindow* window, _GLFWmonitor* monitor, int xpos, int ypos, int width, int height, int refreshRate);
 GLFWbool _glfwWindowFocusedX11(_GLFWwindow* window);
 GLFWbool _glfwWindowIconifiedX11(_GLFWwindow* window);

--- a/src/x11_platform.h
+++ b/src/x11_platform.h
@@ -605,6 +605,7 @@ typedef struct _GLFWlibraryX11
     Atom            NET_WM_STATE_MAXIMIZED_VERT;
     Atom            NET_WM_STATE_MAXIMIZED_HORZ;
     Atom            NET_WM_STATE_DEMANDS_ATTENTION;
+    Atom            NET_WM_STATE_SKIP_TASKBAR;
     Atom            NET_WM_BYPASS_COMPOSITOR;
     Atom            NET_WM_FULLSCREEN_MONITORS;
     Atom            NET_WM_WINDOW_OPACITY;

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -1890,7 +1890,35 @@ static void processEvent(XEvent *event)
             if (window->monitor && window->autoIconify)
                 _glfwIconifyWindowX11(window);
 
-            _glfwInputWindowFocus(window, GLFW_FALSE);
+            // Check if a pointer button is physically held. If so, hide
+            // button state so _glfwInputWindowFocus doesn't synthesize
+            // releases that break in-progress drags.
+            {
+                Window root, child;
+                int rootX, rootY, winX, winY;
+                unsigned int mask;
+                XQueryPointer(_glfw.x11.display, window->x11.handle,
+                              &root, &child, &rootX, &rootY,
+                              &winX, &winY, &mask);
+
+                if (mask & (Button1Mask | Button2Mask | Button3Mask |
+                            Button4Mask | Button5Mask))
+                {
+                    GLFWbool saved[GLFW_MOUSE_BUTTON_LAST + 1];
+                    for (int i = 0; i <= GLFW_MOUSE_BUTTON_LAST; i++)
+                    {
+                        saved[i] = window->mouseButtons[i];
+                        window->mouseButtons[i] = GLFW_RELEASE;
+                    }
+                    _glfwInputWindowFocus(window, GLFW_FALSE);
+                    for (int i = 0; i <= GLFW_MOUSE_BUTTON_LAST; i++)
+                        window->mouseButtons[i] = saved[i];
+                }
+                else
+                {
+                    _glfwInputWindowFocus(window, GLFW_FALSE);
+                }
+            }
             return;
         }
 

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -2615,19 +2615,9 @@ void _glfwFocusWindowX11(_GLFWwindow* window)
 
 void _glfwDragWindowX11(_GLFWwindow* window)
 {
-    // No-op on X11. The equivalent of xdg_toplevel.move is
-    // _NET_WM_MOVERESIZE, but handing the drag to the WM that way captures
-    // pointer events for the duration of the move, which would prevent the
-    // application from hit-testing the dragged window against drop targets.
-    //
-    // X11 has implicit pointer capture: once a button is pressed on a
-    // window, all subsequent motion/release events are delivered to that
-    // window regardless of where the cursor physically is. That's enough
-    // for an application to drive a drag via glfwSetWindowPos each frame,
-    // while still receiving motion events that it can use for drop
-    // detection. Callers can use the titlebar hit-test callback
-    // (glfwSetTitlebarHitTestCallback) when they want the classic
-    // WM-driven move behaviour.
+    // No-op: X11's implicit pointer capture lets callers drive the drag
+    // via glfwSetWindowPos. _NET_WM_MOVERESIZE would steal pointer events
+    // and prevent drop-target hit-testing.
     (void)window;
 }
 

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -2613,6 +2613,40 @@ void _glfwFocusWindowX11(_GLFWwindow* window)
     XFlush(_glfw.x11.display);
 }
 
+void _glfwDragWindowX11(_GLFWwindow* window)
+{
+    // Equivalent of xdg_toplevel.move / WM_SYSCOMMAND SC_MOVE for X11: send
+    // _NET_WM_MOVERESIZE with direction=MOVE, and the WM takes over pointer
+    // tracking until the user releases the button. Matches the behaviour
+    // used by the titlebar-drag path in the button-press handler.
+    if (!_glfw.x11.NET_WM_MOVERESIZE)
+        return;
+
+    Window root, child;
+    int rootX, rootY, winX, winY;
+    unsigned int mask;
+    if (!XQueryPointer(_glfw.x11.display, window->x11.handle,
+                       &root, &child, &rootX, &rootY, &winX, &winY, &mask))
+        return;
+
+    XUngrabPointer(_glfw.x11.display, CurrentTime);
+
+    XEvent xev = { 0 };
+    xev.type = ClientMessage;
+    xev.xclient.window = window->x11.handle;
+    xev.xclient.message_type = _glfw.x11.NET_WM_MOVERESIZE;
+    xev.xclient.format = 32;
+    xev.xclient.data.l[0] = rootX;
+    xev.xclient.data.l[1] = rootY;
+    xev.xclient.data.l[2] = 8; // _NET_WM_MOVERESIZE_MOVE
+    xev.xclient.data.l[3] = Button1;
+    xev.xclient.data.l[4] = 1; // source: normal app
+
+    XSendEvent(_glfw.x11.display, _glfw.x11.root, False,
+               SubstructureRedirectMask | SubstructureNotifyMask, &xev);
+    XFlush(_glfw.x11.display);
+}
+
 void _glfwSetWindowMonitorX11(_GLFWwindow* window,
                               _GLFWmonitor* monitor,
                               int xpos, int ypos,

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -645,7 +645,7 @@ static GLFWbool createNativeWindow(_GLFWwindow* window,
 
     if (_glfw.x11.NET_WM_STATE && !window->monitor)
     {
-        Atom states[3];
+        Atom states[4];
         int count = 0;
 
         if (wndconfig->floating)
@@ -663,6 +663,12 @@ static GLFWbool createNativeWindow(_GLFWwindow* window,
                 states[count++] = _glfw.x11.NET_WM_STATE_MAXIMIZED_HORZ;
                 window->x11.maximized = GLFW_TRUE;
             }
+        }
+
+        if (!wndconfig->focusOnShow)
+        {
+            if (_glfw.x11.NET_WM_STATE_SKIP_TASKBAR)
+                states[count++] = _glfw.x11.NET_WM_STATE_SKIP_TASKBAR;
         }
 
         if (count)

--- a/src/x11_window.c
+++ b/src/x11_window.c
@@ -2615,36 +2615,20 @@ void _glfwFocusWindowX11(_GLFWwindow* window)
 
 void _glfwDragWindowX11(_GLFWwindow* window)
 {
-    // Equivalent of xdg_toplevel.move / WM_SYSCOMMAND SC_MOVE for X11: send
-    // _NET_WM_MOVERESIZE with direction=MOVE, and the WM takes over pointer
-    // tracking until the user releases the button. Matches the behaviour
-    // used by the titlebar-drag path in the button-press handler.
-    if (!_glfw.x11.NET_WM_MOVERESIZE)
-        return;
-
-    Window root, child;
-    int rootX, rootY, winX, winY;
-    unsigned int mask;
-    if (!XQueryPointer(_glfw.x11.display, window->x11.handle,
-                       &root, &child, &rootX, &rootY, &winX, &winY, &mask))
-        return;
-
-    XUngrabPointer(_glfw.x11.display, CurrentTime);
-
-    XEvent xev = { 0 };
-    xev.type = ClientMessage;
-    xev.xclient.window = window->x11.handle;
-    xev.xclient.message_type = _glfw.x11.NET_WM_MOVERESIZE;
-    xev.xclient.format = 32;
-    xev.xclient.data.l[0] = rootX;
-    xev.xclient.data.l[1] = rootY;
-    xev.xclient.data.l[2] = 8; // _NET_WM_MOVERESIZE_MOVE
-    xev.xclient.data.l[3] = Button1;
-    xev.xclient.data.l[4] = 1; // source: normal app
-
-    XSendEvent(_glfw.x11.display, _glfw.x11.root, False,
-               SubstructureRedirectMask | SubstructureNotifyMask, &xev);
-    XFlush(_glfw.x11.display);
+    // No-op on X11. The equivalent of xdg_toplevel.move is
+    // _NET_WM_MOVERESIZE, but handing the drag to the WM that way captures
+    // pointer events for the duration of the move, which would prevent the
+    // application from hit-testing the dragged window against drop targets.
+    //
+    // X11 has implicit pointer capture: once a button is pressed on a
+    // window, all subsequent motion/release events are delivered to that
+    // window regardless of where the cursor physically is. That's enough
+    // for an application to drive a drag via glfwSetWindowPos each frame,
+    // while still receiving motion events that it can use for drop
+    // detection. Callers can use the titlebar hit-test callback
+    // (glfwSetTitlebarHitTestCallback) when they want the classic
+    // WM-driven move behaviour.
+    (void)window;
 }
 
 void _glfwSetWindowMonitorX11(_GLFWwindow* window,


### PR DESCRIPTION
I changed a lot of the Wayland backend to fix a lot of problems:

1.     DPI is now calculated correctly, with fractional scaling
2.     Undecorated windows are draggable via the title bar
3.     Undecorated windows are resizable via their edges
4.     Resizing edges are disabled for maximised windows
5.     The mouse cursor appears as a resize cursor while hovering the edge of the window
6.     There is only one function that decides what shape the cursor should be, avoiding glitchiness
7.     Native cursor shapes are preferred

And more!